### PR TITLE
ログインページと新規登録ページのスタイリング,フッターを最下部へ固定

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -4,7 +4,14 @@
   height: 100%;
   width: 100%;
 }
-
+body {
+  min-height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+.page-wrapper {
+  flex: 1;  // footerを最下部に固定するため
+}
 // header
 .navbar {
   padding: .8rem;
@@ -54,6 +61,26 @@
 .description {
   line-height: 200%;
 }
+
+
+// signup, login
+.card-container {
+  background-color: #f7f7f7;
+  padding: 50px;
+  margin: 2rem auto;
+  max-width: 400px;
+  box-shadow: 0 2px 2px rgba(0, 0, 0, 0.3);
+}
+.placeholder {
+  font-size: .8rem;
+  color: #555;
+}
+.invite-text {
+  display: inline-block;
+  margin-top: .5rem;
+  font-size: .9rem;
+}
+
 
 // footer
 footer {

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -12,5 +12,6 @@
     = render 'layouts/header'
     - flash.each do |msg_type, msg|
       = content_tag(:div, msg, class: "alert alert-#{msg_type}")
-    = yield
+    .page-wrapper
+      = yield
     = render 'layouts/footer'

--- a/app/views/sessions/new.html.haml
+++ b/app/views/sessions/new.html.haml
@@ -1,17 +1,14 @@
-%h1.text-center ログイン（仮）
-
 .container
-  = form_for(:session, url: login_path) do |f|
-    = f.label :email
-    = f.email_field :email, class: "form-control"
+  .card.card-container
+    = image_tag "logo.png", size: "200x55", class: "mx-auto"
+    = form_for(:session, url: login_path) do |f|
+      = f.email_field :email, class: "form-control placeholder mt-5 mb-4", placeholder: "メールアドレス"
 
-    = f.label :password
-    = f.password_field :password, class: "form-control"
+      = f.password_field :password, class: "form-control placeholder mb-3", placeholder: "パスワード"
 
-    = f.label :remember_me, class: "checkbox inline" do
-      = f.check_box :remember_me
-      %span このパソコンを記憶する
+      = f.label :remember_me, class: "checkbox inline mb-4" do
+        = f.check_box :remember_me
+        %span.ml-1 次回から自動でログインする
 
-    = f.submit "ログイン", class: "btn btn-primary btn-block mt-2"
-  %p
-    = link_to "新規登録はこちら", signup_path
+      = f.submit "ログイン", class: "btn btn-success btn-block mt-2"
+      = link_to "パスワードをお忘れの場合", "#", class: "invite-text"

--- a/app/views/static_pages/home.html.haml
+++ b/app/views/static_pages/home.html.haml
@@ -4,7 +4,7 @@
     .img-caption
       %h3 習慣づくりの第１歩
       %h1.display-2 MakeHabits
-  .container-fluid.padding.bg-light
+  .container-fluid.padding
     .row.welcome.text-center
       .col-12
         %h1.display-4 What is MakeHabits ?

--- a/app/views/users/new.html.haml
+++ b/app/views/users/new.html.haml
@@ -1,15 +1,15 @@
-%h1.text-center ユーザー登録（仮）
-
 .container
-  = form_for(@user) do |f|
-    = render "shared/error_messages", object: f.object
-    = f.label :name
-    = f.text_field :name, class: "form-control"
+  .card.card-container
+    = image_tag "logo.png", size: "200x55", class: "mx-auto"
+    = form_for(@user) do |f|
+      = render "shared/error_messages", object: f.object
+      = f.text_field :name, class: "form-control placeholder mt-5 mb-4", placeholder: "ユーザー名"
 
-    = f.label :email
-    = f.email_field :email, class: "form-control"
+      = f.email_field :email, class: "form-control placeholder mb-4", placeholder: "メールアドレス"
 
-    = f.label :password
-    = f.password_field :password, class: "form-control"
+      = f.password_field :password, class: "form-control placeholder mb-4", placeholder: "パスワード（６文字以上）"
 
-    = f.submit "新規登録", class: "btn btn-primary mt-2"
+      = f.password_field :password_confirmation, class: "form-control placeholder mb-5", placeholder: "パスワード（確認）"
+
+      = f.submit "新規登録", class: "btn btn-primary btn-block"
+      = link_to "すでにアカウントをお持ちの場合", login_path, class: "invite-text"


### PR DESCRIPTION
issue #16 #6 

## 概要
- ログインページと新規登録ページのスタイリング
- コンテンツ量が少ないページでもフッターを最下部に表示する

## 参考URL
https://coliss.com/articles/build-websites/operation/css/css-sticky-footer.html