### PR TITLE
アカウント有効化機能の実装

### DIFF
--- a/app/assets/javascripts/account_activations.coffee
+++ b/app/assets/javascripts/account_activations.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/account_activations.scss
+++ b/app/assets/stylesheets/account_activations.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the AccountActivations controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/account_activations_controller.rb
+++ b/app/controllers/account_activations_controller.rb
@@ -1,0 +1,14 @@
+class AccountActivationsController < ApplicationController
+  def edit
+    user = User.find_by(email: params[:email])
+    if user && !user.activated? && user.authenticated?(:activation, params[:id])
+      user.activate
+      log_in user
+      flash[:success] = "アカウントを有効化しました"
+      redirect_to user
+    else
+      flash[:danger] = "このリンクは無効です"
+      redirect_to root_url
+    end
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,6 +6,7 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
+      @user.send_activation_email
       log_in @user
       flash[:success] = "ユーザー登録しました"
       redirect_to @user

--- a/app/helpers/account_activations_helper.rb
+++ b/app/helpers/account_activations_helper.rb
@@ -1,0 +1,2 @@
+module AccountActivationsHelper
+end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -14,7 +14,7 @@ module SessionsHelper
       @current_user ||= User.find_by(id: user_id)
     elsif (user_id = cookies.signed[:user_id])
       user = User.find_by(id: user_id)
-      if user && user.authenticated?(cookies[:remember_token])
+      if user && user.authenticated?(:remember, cookies[:remember_token])
         log_in user
         @current_user = user
       end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
+  default from: 'noreply@example.com'
   layout 'mailer'
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,0 +1,23 @@
+class UserMailer < ApplicationMailer
+
+  # Subject can be set in your I18n file at config/locales/en.yml
+  # with the following lookup:
+  #
+  #   en.user_mailer.account_activation.subject
+  #
+  def account_activation(user)
+    @user = user
+    mail to: user.email, subject: "【MakeHabits】アカウント有効化"
+  end
+
+  # Subject can be set in your I18n file at config/locales/en.yml
+  # with the following lookup:
+  #
+  #   en.user_mailer.password_reset.subject
+  #
+  def password_reset
+    @greeting = "Hi"
+
+    mail to: "to@example.org"
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 class User < ApplicationRecord
-  attr_accessor :remember_token
-  before_save { self.email = email.downcase }
+  attr_accessor :remember_token, :activation_token
+  before_save :downcase_email
+  before_create :create_activation_digest
   validates :name, presence: true, length: { maximum: 50 }
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
   validates :email, presence: true, length: { maximum: 255 },
@@ -25,12 +26,31 @@ class User < ApplicationRecord
     update_attribute(:remember_digest, User.digest(remember_token))
   end
 
-  def authenticated?(remember_token)
-    return false if remember_digest.nil?
-    BCrypt::Password.new(remember_digest).is_password?(remember_token)
+  def authenticated?(attribute, token)
+    digest = send("#{attribute}_digest")
+    return false if digest.nil?
+    BCrypt::Password.new(digest).is_password?(token)
   end
 
   def forget
     update_attribute(:remember_digest, nil)
   end
+
+  def activate
+    update_attribute(:activated, true)
+  end
+
+  def send_activation_email
+    UserMailer.account_activation(self).deliver_now
+  end
+
+  private
+    def downcase_email
+      self.email.downcase!
+    end
+
+    def create_activation_digest
+      self.activation_token = User.new_token
+      self.activation_digest = User.digest(activation_token)
+    end
 end

--- a/app/views/user_mailer/account_activation.html.haml
+++ b/app/views/user_mailer/account_activation.html.haml
@@ -1,0 +1,11 @@
+%p
+  = @user.name + "さん"
+%p
+  MakeHabitsをご利用いただきありがとうございます！
+  %br
+  下記のリンクにアクセスしてアカウントを有効化してください。
+  %br
+  （アカウントが有効化されていないとパスワードを変更することができません。）
+
+= link_to "アカウントを有効化する", edit_account_activation_url(@user.activation_token,
+                                                                email: @user.email)

--- a/app/views/user_mailer/account_activation.text.haml
+++ b/app/views/user_mailer/account_activation.text.haml
@@ -1,0 +1,6 @@
+= @user.name + "さん"
+
+MakeHabitsをご利用いただきありがとうございます！
+下記のリンクにアクセスしてアカウントを有効化してください。
+（アカウントが有効化されていないとパスワードを変更することができません。）
+= edit_account_activation_url(@user.activation_token, email: @user.email)

--- a/app/views/user_mailer/password_reset.html.haml
+++ b/app/views/user_mailer/password_reset.html.haml
@@ -1,0 +1,4 @@
+%h1= class_name + "#" + @action
+
+%p
+  = @greeting + ", find me in app/views/user_mailer/password_reset.html.haml"

--- a/app/views/user_mailer/password_reset.text.haml
+++ b/app/views/user_mailer/password_reset.text.haml
@@ -1,0 +1,3 @@
+UserMailer#password_reset
+
+= @greeting + ", find me in app/views/user_mailer/password_reset.text.haml"

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -4,3 +4,5 @@
   = @user.name
 %p
   = @user.email
+%p
+  = "activated:" + "#{@user.activated}"

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -31,7 +31,10 @@ Rails.application.configure do
   config.active_storage.service = :local
 
   # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.delivery_method = :test
+  host = 'localhost:3000'
+  config.action_mailer.default_url_options = { host: host, protocol: 'http' }
 
   config.action_mailer.perform_caching = false
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,4 +5,5 @@ Rails.application.routes.draw do
   post '/login', to: 'sessions#create'
   delete 'logout', to: 'sessions#destroy'
   resources :users, only: [:new, :create, :show]
+  resources :account_activations, only: [:edit]
 end

--- a/db/migrate/20190301150451_add_activation_to_users.rb
+++ b/db/migrate/20190301150451_add_activation_to_users.rb
@@ -1,0 +1,6 @@
+class AddActivationToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :activation_digest, :string
+    add_column :users, :activated, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_28_081842) do
+ActiveRecord::Schema.define(version: 2019_03_01_150451) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,6 +22,8 @@ ActiveRecord::Schema.define(version: 2019_02_28_081842) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "remember_digest"
+    t.string "activation_digest"
+    t.boolean "activated", default: false
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/test/controllers/account_activations_controller_test.rb
+++ b/test/controllers/account_activations_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class AccountActivationsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -1,0 +1,16 @@
+# Preview all emails at http://localhost:3000/rails/mailers/user_mailer
+class UserMailerPreview < ActionMailer::Preview
+
+  # Preview this email at http://localhost:3000/rails/mailers/user_mailer/account_activation
+  def account_activation
+    user = User.first
+    user.activation_token = User.new_token
+    UserMailer.account_activation(user)
+  end
+
+  # Preview this email at http://localhost:3000/rails/mailers/user_mailer/password_reset
+  def password_reset
+    UserMailer.password_reset
+  end
+
+end

--- a/test/mailers/user_mailer_test.rb
+++ b/test/mailers/user_mailer_test.rb
@@ -1,0 +1,20 @@
+require 'test_helper'
+
+class UserMailerTest < ActionMailer::TestCase
+  test "account_activation" do
+    mail = UserMailer.account_activation
+    assert_equal "Account activation", mail.subject
+    assert_equal ["to@example.org"], mail.to
+    assert_equal ["from@example.com"], mail.from
+    assert_match "Hi", mail.body.encoded
+  end
+
+  test "password_reset" do
+    mail = UserMailer.password_reset
+    assert_equal "Password reset", mail.subject
+    assert_equal ["to@example.org"], mail.to
+    assert_equal ["from@example.com"], mail.from
+    assert_match "Hi", mail.body.encoded
+  end
+
+end


### PR DESCRIPTION
issue #25 

## 概要
- メール送付によるアカウント有効化機能の実装

## テスト内容
- ユーザー登録時にアカウント有効化メールが発行されることをコンソール上で確認
- アカウント有効化メールのリンクにアクセスするとアカウントが有効化される（activatedがtrueになる）ことを確認
- すでに有効化させたアカウントで再度有効化リンクにアクセスしたら失敗することを確認

## 補足
- 本番環境でのメール送信機能はまだなので別issueで対応
- アカウントが有効化されていなくてもパスワード変更機能以外は使えるようにする予定なので、現時点でアカウントが有効化されていなくても制限はない
  - パスワード変更機能を実装する際に(issue #20 )アカウントが有効化されているかどうかの場合分けとアカウント有効化メールの再送信機能を実装