### PR TITLE
パスワード再設定機能の実装

### DIFF
--- a/app/assets/javascripts/password_resets.coffee
+++ b/app/assets/javascripts/password_resets.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/password_resets.scss
+++ b/app/assets/stylesheets/password_resets.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the PasswordResets controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -1,0 +1,69 @@
+class PasswordResetsController < ApplicationController
+  before_action :get_user, only: [:edit, :update]
+  before_action :valid_user, only: [:edit, :update]
+  before_action :check_expiration, only: [:edit, :update]
+
+  def new
+  end
+
+  def create
+    @user = User.find_by(email: params[:password_reset][:email].downcase)
+    unless @user
+      flash.now[:danger] = "メールアドレスが間違っています"
+      render :new and return
+    end
+    if @user.activated
+      @user.create_reset_digest
+      @user.send_password_reset_email
+      flash[:info] = "メールを送信しました"
+      redirect_to root_url
+    else
+      flash.now[:danger] = "アカウントが有効化されていません"
+      render :new
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if params[:user][:password].empty?
+      # ユーザー編集機能を作る際にUserモデルのpasswordに,
+      # allow_nill: trueを実装しても不具合が起こらないようにするため
+      @user.errors.add(:password, :blank)
+      render :edit
+    elsif @user.update_attributes(user_params)
+      log_in @user
+      @user.update_attribute(:reset_digest, nil)
+      flash[:success] = "パスワードを更新しました"
+      redirect_to @user
+    else
+      render :edit
+    end
+  end
+
+  private
+
+    def user_params
+      params.require(:user).permit(:password, :password_confirmation)
+    end
+
+    def get_user
+      @user = User.find_by(email: params[:email])
+    end
+
+    def valid_user
+      unless(@user && @user.activated? &&
+             @user.authenticated?(:reset, params[:id]))
+        flash[:danger] = "このリンクは無効です"
+        redirect_to root_url
+      end
+    end
+
+    def check_expiration
+      if @user.password_reset_expired?
+        flash[:danger] = "リンクの有効期限が切れています"
+        redirect_to new_password_reset_url
+      end
+    end
+end

--- a/app/helpers/password_resets_helper.rb
+++ b/app/helpers/password_resets_helper.rb
@@ -1,0 +1,2 @@
+module PasswordResetsHelper
+end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -15,9 +15,8 @@ class UserMailer < ApplicationMailer
   #
   #   en.user_mailer.password_reset.subject
   #
-  def password_reset
-    @greeting = "Hi"
-
-    mail to: "to@example.org"
+  def password_reset(user)
+    @user = user
+    mail to: user.email, subject: "【MakeHabits】パスワード再設定"
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,5 @@
 class User < ApplicationRecord
-  attr_accessor :remember_token, :activation_token
+  attr_accessor :remember_token, :activation_token, :reset_token
   before_save :downcase_email
   before_create :create_activation_digest
   validates :name, presence: true, length: { maximum: 50 }
@@ -42,6 +42,19 @@ class User < ApplicationRecord
 
   def send_activation_email
     UserMailer.account_activation(self).deliver_now
+  end
+
+  def create_reset_digest
+    self.reset_token = User.new_token
+    update_columns(reset_digest: User.digest(reset_token), reset_sent_at: Time.zone.now)
+  end
+
+  def send_password_reset_email
+    UserMailer.password_reset(self).deliver_now
+  end
+
+  def password_reset_expired?
+    reset_sent_at < 2.hours.ago
   end
 
   private

--- a/app/views/password_resets/edit.html.haml
+++ b/app/views/password_resets/edit.html.haml
@@ -1,0 +1,13 @@
+%h1
+  パスワードをリセットする（仮）
+
+= form_for(@user, url: password_reset_path(params[:id])) do |f|
+  = render "shared/error_messages", object: f.object
+
+  = hidden_field_tag :email, @user.email
+
+  = f.password_field :password, class: "form-control placeholder", placeholder: "パスワード（６文字以上）"
+
+  = f.password_field :password_confirmation, class: "form-control placeholder", placeholder: "パスワード（確認）"
+
+  = f.submit "パスワードをリセットする", class: "btn btn-primary"

--- a/app/views/password_resets/new.html.haml
+++ b/app/views/password_resets/new.html.haml
@@ -1,0 +1,7 @@
+.container
+  %h1
+    パスワードをリセット（仮）
+  = form_for(:password_reset, url: password_resets_path) do |f|
+    = f.email_field :email, class: "form-control placeholder", placeholder: "メールアドレス"
+
+    = f.submit "パスワードをリセット", class: "btn btn-primary"

--- a/app/views/sessions/new.html.haml
+++ b/app/views/sessions/new.html.haml
@@ -11,4 +11,4 @@
         %span.ml-1 次回から自動でログインする
 
       = f.submit "ログイン", class: "btn btn-success btn-block mt-2"
-      = link_to "パスワードをお忘れの場合", "#", class: "invite-text"
+      = link_to "パスワードをお忘れの場合", new_password_reset_path, class: "invite-text"

--- a/app/views/user_mailer/password_reset.html.haml
+++ b/app/views/user_mailer/password_reset.html.haml
@@ -1,4 +1,5 @@
-%h1= class_name + "#" + @action
-
 %p
-  = @greeting + ", find me in app/views/user_mailer/password_reset.html.haml"
+  パスワードを再設定する場合は以下のリンクにアクセスしてください。
+= link_to "パスワードを再設定する", edit_password_reset_url(@user.reset_token, email: @user.email)
+%p
+  このリンクの有効期限は発行から２時間です。

--- a/app/views/user_mailer/password_reset.text.haml
+++ b/app/views/user_mailer/password_reset.text.haml
@@ -1,3 +1,3 @@
-UserMailer#password_reset
-
-= @greeting + ", find me in app/views/user_mailer/password_reset.text.haml"
+パスワードを再設定する場合は以下のリンクにアクセスしてください。
+= edit_password_reset_url(@user.reset_token, email: @user.email)
+このリンクの有効期限は発行から２時間です。

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,4 +6,5 @@ Rails.application.routes.draw do
   delete 'logout', to: 'sessions#destroy'
   resources :users, only: [:new, :create, :show]
   resources :account_activations, only: [:edit]
+  resources :password_resets, only: [:new, :create, :edit, :update]
 end

--- a/db/migrate/20190301180103_add_reset_to_users.rb
+++ b/db/migrate/20190301180103_add_reset_to_users.rb
@@ -1,0 +1,6 @@
+class AddResetToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :reset_digest, :string
+    add_column :users, :reset_sent_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_01_150451) do
+ActiveRecord::Schema.define(version: 2019_03_01_180103) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -24,6 +24,8 @@ ActiveRecord::Schema.define(version: 2019_03_01_150451) do
     t.string "remember_digest"
     t.string "activation_digest"
     t.boolean "activated", default: false
+    t.string "reset_digest"
+    t.datetime "reset_sent_at"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -10,7 +10,9 @@ class UserMailerPreview < ActionMailer::Preview
 
   # Preview this email at http://localhost:3000/rails/mailers/user_mailer/password_reset
   def password_reset
-    UserMailer.password_reset
+    user = User.first
+    user.reset_token = User.new_token
+    UserMailer.password_reset(user)
   end
 
 end


### PR DESCRIPTION
close #20 

## 概要
- 有効化されたアカウントではパスワードを再設定できるようにした

## テスト内容
- 開発環境においてパスワードを再設定できることを確認
- 有効化していないアカウントのパスワードは変更できないことを確認
- パスワードを変更したらそのリンクは無効になる(reset_digestがnullになる)ことを確認
- 有効期限が切れたリンクからはパスワードが変更できないことを確認
  - 確認は期限を短くして行った

## 参考URL
- http://www.convertstring.com/ja/EncodeDecode/Base64Decode
  - サーバーに表示されるメールの形式がbase64だったためデコードのために使用