### PR TITLE
本番環境でのメール送信機能の実装

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -67,7 +67,19 @@ Rails.application.configure do
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  # config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.delivery_method = :smtp
+  host = 'make-habits.herokuapp.com'
+  config.action_mailer.default_url_options = { host: host }
+  ActionMailer::Base.smtp_settings = {
+    :address        => 'smtp.sendgrid.net',
+    :port           => '587',
+    :authentication => :plain,
+    :user_name      => ENV['SENDGRID_USERNAME'],
+    :password       => ENV['SENDGRID_PASSWORD'],
+    :domain         => 'heroku.com',
+    :enable_starttls_auto => true
+  }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).


### PR DESCRIPTION
close #27 

## 概要
- SendGridの設定を行い本番環境でのメール送信機能を実装
  - herokuにアドオンを追加
  - production環境用の設定

## テスト内容
- トピックブランチをherokuにデプロイし、実際にメールが届いてアカウント有効化とパスワードの再設定が実行できることを確認

## 参考URL
[Herokuにmasterブランチ以外をdeployする方法](https://qiita.com/wroc/items/d15b1015c899b0cf77da)