### PR TITLE
パスワードリセット画面のスタイリング

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,6 +1,6 @@
- @import "bootstrap";
+@import "bootstrap";
 
- html, body {
+html, body {
   height: 100%;
   width: 100%;
 }
@@ -12,6 +12,7 @@ body {
 .page-wrapper {
   flex: 1;  // footerを最下部に固定するため
 }
+
 // header
 .navbar {
   padding: .8rem;
@@ -62,7 +63,6 @@ body {
   line-height: 200%;
 }
 
-
 // signup, login
 .card-container {
   background-color: #f7f7f7;
@@ -77,10 +77,20 @@ body {
 }
 .invite-text {
   display: inline-block;
-  margin-top: .5rem;
+  margin-top: .8rem;
   font-size: .9rem;
 }
 
+// password-reset
+.password-reset-wrapper {
+  max-width: 800px;
+  .heading {
+    font-weight: 600;
+    border-bottom: .7px solid #ccc;
+    margin: 3rem 0 2rem;
+    padding-bottom: .7rem
+  }
+}
 
 // footer
 footer {
@@ -125,5 +135,21 @@ footer {
   }
   .description {
     font-size: 90%;
+  }
+  .invite-text {
+    display: inline-block;
+    margin-top: 1.2rem;
+    font-size: .7rem;
+  }
+  .password-reset-wrapper {
+    h2 {
+      font-size: 1.5rem;
+    }
+    p {
+      font-size: .8rem;
+    }
+    .btn {
+      width: 100%;
+    }
   }
 }

--- a/app/views/password_resets/edit.html.haml
+++ b/app/views/password_resets/edit.html.haml
@@ -1,13 +1,17 @@
-%h1
-  パスワードをリセットする（仮）
+.container.password-reset-wrapper
+  .row
+    .col-sm-10.offset-sm-1
+      %h2.heading
+        パスワードを変更する
+      %p
+        新しいパスワードを入力してください
+      = form_for(@user, url: password_reset_path(params[:id])) do |f|
+        = render "shared/error_messages", object: f.object
 
-= form_for(@user, url: password_reset_path(params[:id])) do |f|
-  = render "shared/error_messages", object: f.object
+        = hidden_field_tag :email, @user.email
 
-  = hidden_field_tag :email, @user.email
+        = f.password_field :password, class: "form-control placeholder my-4", placeholder: "パスワード（６文字以上）"
 
-  = f.password_field :password, class: "form-control placeholder", placeholder: "パスワード（６文字以上）"
+        = f.password_field :password_confirmation, class: "form-control placeholder mb-4", placeholder: "パスワード（確認）"
 
-  = f.password_field :password_confirmation, class: "form-control placeholder", placeholder: "パスワード（確認）"
-
-  = f.submit "パスワードをリセットする", class: "btn btn-primary"
+        = f.submit "パスワードを変更する", class: "btn btn-primary"

--- a/app/views/password_resets/new.html.haml
+++ b/app/views/password_resets/new.html.haml
@@ -1,7 +1,14 @@
-.container
-  %h1
-    パスワードをリセット（仮）
-  = form_for(:password_reset, url: password_resets_path) do |f|
-    = f.email_field :email, class: "form-control placeholder", placeholder: "メールアドレス"
-
-    = f.submit "パスワードをリセット", class: "btn btn-primary"
+.container.password-reset-wrapper
+  .row
+    .col-sm-10.offset-sm-1
+      %h2.heading
+        パスワードをリセット
+      %p
+        登録したメールアドレスを入力してください。
+      %p
+        パスワード変更ページのURLを記載したメールを送信します。
+      = form_for(:password_reset, url: password_resets_path) do |f|
+        = f.email_field :email, class: "form-control placeholder mt-3", placeholder: "メールアドレス"
+        %div
+          = f.submit "メールを送信する", class: "btn btn-secondary mt-4"
+        = link_to "ログインはこちら", login_path, class: "invite-text display-block"


### PR DESCRIPTION
close #30 

## 概要
- パスワード変更のメール送信画面とパスワード変更画面をスタイリング
- スマホ表示対応

## テスト内容
- chromeの検証ツールで表示を確認

## 補足
- レスポンシブ対応においてはフォントサイズを気にしてあげなきゃダメ
- iPhoneSEとiPhone X ではだいぶ表示違ってやっかい
- タブレットは現状そこまで気にしなくてよさそうだけど、微調整するならあとでまとめてやる