### PR TITLE
エラーメッセージの日本語化とスタイリング

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -9,6 +9,11 @@ body {
   display: flex;
   flex-direction: column;
 }
+ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
 .page-wrapper {
   flex: 1;  // footerを最下部に固定するため
 }
@@ -22,6 +27,11 @@ body {
 }
 .nav-link {
   font-size: 1.1em !important;
+}
+
+// error message
+.error-message {
+  font-size: .8rem;
 }
 
 // top page

--- a/app/views/password_resets/edit.html.haml
+++ b/app/views/password_resets/edit.html.haml
@@ -12,6 +12,6 @@
 
         = f.password_field :password, class: "form-control placeholder my-4", placeholder: "パスワード（６文字以上）"
 
-        = f.password_field :password_confirmation, class: "form-control placeholder mb-4", placeholder: "パスワード（確認）"
+        = f.password_field :password_confirmation, class: "form-control placeholder mb-4", placeholder: "パスワード（確認のためにもう一度入力してください）"
 
         = f.submit "パスワードを変更する", class: "btn btn-primary"

--- a/app/views/shared/_error_messages.html.haml
+++ b/app/views/shared/_error_messages.html.haml
@@ -1,5 +1,6 @@
 - if object.errors.any?
-  %ul
-    - object.errors.full_messages.each do |msg|
-      %li 
-        =msg
+  .error-message.alert.alert-warning.mt-3
+    %ul
+      - object.errors.full_messages.each do |msg|
+        %li.py-1
+          =msg

--- a/app/views/users/new.html.haml
+++ b/app/views/users/new.html.haml
@@ -9,7 +9,7 @@
 
       = f.password_field :password, class: "form-control placeholder mb-4", placeholder: "パスワード（６文字以上）"
 
-      = f.password_field :password_confirmation, class: "form-control placeholder mb-5", placeholder: "パスワード（確認）"
+      = f.password_field :password_confirmation, class: "form-control placeholder mb-5", placeholder: "パスワード（確認のためにもう一度入力してください）"
 
       = f.submit "新規登録", class: "btn btn-primary btn-block"
       = link_to "すでにアカウントをお持ちの場合", login_path, class: "invite-text"

--- a/config/initializers/locale.rb
+++ b/config/initializers/locale.rb
@@ -1,0 +1,1 @@
+Rails.application.config.i18n.default_locale = :ja

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,224 @@
+---
+ja:
+  activerecord:
+    errors:
+      messages:
+        record_invalid: 'バリデーションに失敗しました: %{errors}'
+        restrict_dependent_destroy:
+          has_one: "%{record}が存在しているので削除できません"
+          has_many: "%{record}が存在しているので削除できません"
+    models:
+      user: ユーザー
+    attributes:
+      user:
+        id: ID
+        name: ユーザー名
+        email: メールアドレス
+        password: パスワード
+        password_confirmation: パスワード
+        password_digest:
+        created_at: 登録日時
+        updated_at: 更新日時
+        remember_digest:
+        activation_digest:
+        activated:
+        reset_digest:
+        reset_sent_at:
+  date:
+    abbr_day_names:
+    - 日
+    - 月
+    - 火
+    - 水
+    - 木
+    - 金
+    - 土
+    abbr_month_names:
+    - 
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    day_names:
+    - 日曜日
+    - 月曜日
+    - 火曜日
+    - 水曜日
+    - 木曜日
+    - 金曜日
+    - 土曜日
+    formats:
+      default: "%Y/%m/%d"
+      long: "%Y年%m月%d日(%a)"
+      short: "%m/%d"
+    month_names:
+    - 
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    order:
+    - :year
+    - :month
+    - :day
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: 約1時間
+        other: 約%{count}時間
+      about_x_months:
+        one: 約1ヶ月
+        other: 約%{count}ヶ月
+      about_x_years:
+        one: 約1年
+        other: 約%{count}年
+      almost_x_years:
+        one: 1年弱
+        other: "%{count}年弱"
+      half_a_minute: 30秒前後
+      less_than_x_seconds:
+        one: 1秒以内
+        other: "%{count}秒未満"
+      less_than_x_minutes:
+        one: 1分以内
+        other: "%{count}分未満"
+      over_x_years:
+        one: 1年以上
+        other: "%{count}年以上"
+      x_seconds:
+        one: 1秒
+        other: "%{count}秒"
+      x_minutes:
+        one: 1分
+        other: "%{count}分"
+      x_days:
+        one: 1日
+        other: "%{count}日"
+      x_months:
+        one: 1ヶ月
+        other: "%{count}ヶ月"
+      x_years:
+        one: 1年
+        other: "%{count}年"
+    prompts:
+      second: 秒
+      minute: 分
+      hour: 時
+      day: 日
+      month: 月
+      year: 年
+  errors:
+    format: "%{attribute}%{message}"
+    messages:
+      accepted: を受諾してください
+      blank: を入力してください
+      confirmation: の入力が一致していません
+      empty: を入力してください
+      equal_to: は%{count}にしてください
+      even: は偶数にしてください
+      exclusion: は予約されています
+      greater_than: は%{count}より大きい値にしてください
+      greater_than_or_equal_to: は%{count}以上の値にしてください
+      inclusion: は一覧にありません
+      invalid: は不正な値です
+      less_than: は%{count}より小さい値にしてください
+      less_than_or_equal_to: は%{count}以下の値にしてください
+      model_invalid: 'バリデーションに失敗しました: %{errors}'
+      not_a_number: は数値で入力してください
+      not_an_integer: は整数で入力してください
+      odd: は奇数にしてください
+      other_than: は%{count}以外の値にしてください
+      present: は入力しないでください
+      required: を入力してください
+      taken: はすでに存在します
+      too_long: は%{count}文字以内で入力してください
+      too_short: は%{count}文字以上で入力してください
+      wrong_length: は%{count}文字で入力してください
+    template:
+      body: 次の項目を確認してください
+      header:
+        one: "%{model}にエラーが発生しました"
+        other: "%{model}に%{count}個のエラーが発生しました"
+  helpers:
+    select:
+      prompt: 選択してください
+    submit:
+      create: 登録する
+      submit: 保存する
+      update: 更新する
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%n%u"
+        precision: 0
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: 円
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: 十億
+          million: 百万
+          quadrillion: 千兆
+          thousand: 千
+          trillion: 兆
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n%u"
+        units:
+          byte: バイト
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: "、"
+      two_words_connector: "、"
+      words_connector: "、"
+  time:
+    am: 午前
+    formats:
+      default: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
+      long: "%Y/%m/%d %H:%M"
+      short: "%m/%d %H:%M"
+    pm: 午後


### PR DESCRIPTION
close #13 

## 概要
- [翻訳ファイル](https://github.com/svenfuchs/rails-i18n/blob/master/rails/locale/ja.yml)のダウンロード
- 翻訳ファイルの読み込み
  - `config/initializers/locale.rb`の作成
- `config/locales/ja.yml`にモデルの翻訳情報を追加

## テスト内容
- エラーメッセージが日本語で表示されることを確認
- エラーメッセージにスタイルがあたっていることを確認

## 参考URL
- https://morizyun.github.io/ruby/rails-function-i18n-internationalization.html
- 現場Rails p91, 101