### PR TITLE
habitモデル(make, quit)とruleモデルの作成

### DIFF
--- a/app/models/habit.rb
+++ b/app/models/habit.rb
@@ -4,5 +4,5 @@ class Habit < ApplicationRecord
   validates :user_id, presence: true
 
   belongs_to :user
-  has_many :rules
+  has_many :rules, dependent: :destroy
 end

--- a/app/models/habit.rb
+++ b/app/models/habit.rb
@@ -1,0 +1,8 @@
+class Habit < ApplicationRecord
+  validates :title, presence: true, length: { maximum: 255 }
+  validates :type, presence: true
+  validates :user_id, presence: true
+
+  belongs_to :user
+  has_many :rules
+end

--- a/app/models/make.rb
+++ b/app/models/make.rb
@@ -1,0 +1,2 @@
+class Make < Habit
+end

--- a/app/models/quit.rb
+++ b/app/models/quit.rb
@@ -1,0 +1,2 @@
+class Quit < Habit
+end

--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -1,0 +1,6 @@
+class Rule < ApplicationRecord
+  validates :content, presence: true, length: { maximum: 255 }
+  validates :habit_id, presence: true
+
+  belongs_to :habit
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,10 @@ class User < ApplicationRecord
   has_secure_password
   validates :password, presence: true, length: { minimum: 6 }
 
+  has_many :habits, dependent: :destroy
+  has_many :makes, dependent: :destroy
+  has_many :quits, dependent: :destroy
+
   # ハッシュ値を返す
   def self.digest(string)
     cost = ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST :

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -9,6 +9,10 @@ ja:
           has_many: "%{record}が存在しているので削除できません"
     models:
       user: ユーザー
+      habit: 習慣
+      make: 作りたい習慣
+      quit: やめたい習慣
+      rule: ルール
     attributes:
       user:
         id: ID
@@ -24,6 +28,17 @@ ja:
         activated:
         reset_digest:
         reset_sent_at:
+      habit:
+        title: 習慣名
+        type:
+        user_id:
+        created_at: 登録日時
+        updated_at: 更新日時
+      rule:
+        content: ルール
+        habit_id:
+        created_at: 登録日時
+        updated_at: 更新日時
   date:
     abbr_day_names:
     - 日

--- a/db/migrate/20190302164508_create_habits.rb
+++ b/db/migrate/20190302164508_create_habits.rb
@@ -1,0 +1,11 @@
+class CreateHabits < ActiveRecord::Migration[5.2]
+  def change
+    create_table :habits do |t|
+      t.string :type, null: false
+      t.string :title, null: false
+      t.references :user, foreign_key: true, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190302165901_create_rules.rb
+++ b/db/migrate/20190302165901_create_rules.rb
@@ -1,0 +1,10 @@
+class CreateRules < ActiveRecord::Migration[5.2]
+  def change
+    create_table :rules do |t|
+      t.string :content, null: false
+      t.references :habit, foreign_key: true, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,27 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_01_180103) do
+ActiveRecord::Schema.define(version: 2019_03_02_165901) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "habits", force: :cascade do |t|
+    t.string "type", null: false
+    t.string "title", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_habits_on_user_id"
+  end
+
+  create_table "rules", force: :cascade do |t|
+    t.string "content", null: false
+    t.bigint "habit_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["habit_id"], name: "index_rules_on_habit_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "name", null: false
@@ -29,4 +46,6 @@ ActiveRecord::Schema.define(version: 2019_03_01_180103) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "habits", "users"
+  add_foreign_key "rules", "habits"
 end

--- a/test/fixtures/habits.yml
+++ b/test/fixtures/habits.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  type: 
+  title: MyString
+  user: one
+
+two:
+  type: 
+  title: MyString
+  user: two

--- a/test/fixtures/makes.yml
+++ b/test/fixtures/makes.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/quits.yml
+++ b/test/fixtures/quits.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/rules.yml
+++ b/test/fixtures/rules.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  content: MyString
+  habit: one
+
+two:
+  content: MyString
+  habit: two

--- a/test/models/habit_test.rb
+++ b/test/models/habit_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class HabitTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/make_test.rb
+++ b/test/models/make_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class MakeTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/quit_test.rb
+++ b/test/models/quit_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class QuitTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/rule_test.rb
+++ b/test/models/rule_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class RuleTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
close #36 

## 概要
- habitモデルの作成
  - STIでmakeモデルとquitモデルも作成
- ruleモデルの作成
- モデル同士のリレーションの作成
- `ja.yml`に翻訳情報を追加

## テスト内容
- 適切なリレーションができていることをコンソール上で確認
- オブジェクト同士の紐付きがある状態でも削除できることを確認
- モデルの翻訳情報が呼び出せることをコンソール上で確認
  - `<モデル名>.model_name.human`でモデル名の翻訳, `<モデル名>.human_attribute_name(:カラム名)`でカラムの翻訳を呼び出せる

## 参考URL
- https://qiita.com/yshr04hrk/items/cb7b81c104321f660661
- https://techacademy.jp/my/rails/rails5/monolist#chapter-10