### PR TITLE
Twitterログインボタンの作成

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,7 @@ gem 'erb2haml'
 # bootstrap
 gem 'bootstrap', '~> 4.1.1'
 gem 'jquery-rails'
+gem 'font-awesome-sass', '~> 5.6.1'
 
 # Twitter login
 gem 'omniauth'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,6 +95,8 @@ GEM
     erubis (2.7.0)
     execjs (2.7.0)
     ffi (1.10.0)
+    font-awesome-sass (5.6.1)
+      sassc (>= 1.11)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     haml (5.0.4)
@@ -217,6 +219,9 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    sassc (2.0.1)
+      ffi (~> 1.9)
+      rake
     selenium-webdriver (3.141.0)
       childprocess (~> 0.5)
       rubyzip (~> 1.2, >= 1.2.2)
@@ -269,6 +274,7 @@ DEPENDENCIES
   chromedriver-helper
   coffee-rails (~> 4.2)
   erb2haml
+  font-awesome-sass (~> 5.6.1)
   haml-rails
   jbuilder (~> 2.5)
   jquery-rails

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,4 +1,34 @@
 @import "bootstrap";
+@import "font-awesome-sprockets";
+@import "font-awesome";
+
+@mixin form-divide($line-width) {
+  text-align: center;
+  margin-top: 1.5rem;
+  font-size: .8rem;
+  opacity: 0.5;
+  position: relative;
+  &::before {
+    content: "";
+    display: block;
+    height: 1px;
+    width: $line-width;
+    background-color: rgba(0, 0, 0, 0.5);
+    position: absolute;
+    top: 50%;
+    left: 0;
+  }
+  &::after {
+    content: "";
+    display: block;
+    height: 1px;
+    width: $line-width;
+    background-color: rgba(0, 0, 0, 0.5);
+    position: absolute;
+    top: 50%;
+    right: 0;
+  }
+}
 
 html, body {
   height: 100%;
@@ -90,6 +120,20 @@ ul {
   margin-top: .8rem;
   font-size: .9rem;
 }
+.btn-twitter {
+  background-color: #55acee;
+  color: white;
+  &:hover {
+    color: white;
+    background-color: darken(#55acee, 10%)
+  }
+}
+.divide-text-signup {
+  @include form-divide(50px);
+}
+.divide-text-login {
+  @include form-divide(100px)
+}
 
 // password-reset
 .password-reset-wrapper {
@@ -126,6 +170,9 @@ footer {
   .description {
     font-size: 110%;
   }
+  .btn-signup {
+    margin-top: 3rem !important;
+  }
 }
 @media (max-width: 576px) {
   .img-caption h1 {
@@ -161,5 +208,16 @@ footer {
     .btn {
       width: 100%;
     }
+  }
+  .remember-text {
+    font-size: .8rem;
+    position: relative;
+    top: -1px;
+  }
+  .divide-text-signup {
+    @include form-divide(0);
+  }
+  .divide-text-login {
+    @include form-divide(70px)
   }
 }

--- a/app/views/password_resets/edit.html.haml
+++ b/app/views/password_resets/edit.html.haml
@@ -12,6 +12,6 @@
 
         = f.password_field :password, class: "form-control placeholder my-4", placeholder: "パスワード（６文字以上）"
 
-        = f.password_field :password_confirmation, class: "form-control placeholder mb-4", placeholder: "パスワード（確認のためにもう一度入力してください）"
+        = f.password_field :password_confirmation, class: "form-control placeholder mb-4", placeholder: "パスワード（確認）"
 
         = f.submit "パスワードを変更する", class: "btn btn-primary"

--- a/app/views/sessions/new.html.haml
+++ b/app/views/sessions/new.html.haml
@@ -1,16 +1,18 @@
 .container
   .card.card-container
     = image_tag "logo.png", size: "200x55", class: "mx-auto"
+    = link_to  '/auth/twitter', class: "btn btn-twitter mt-4" do
+      = icon("fab", "twitter", class: "mr-1")
+      %span Twitterでログイン
+    .divide-text-login または
     = form_for(:session, url: login_path) do |f|
-      = f.email_field :email, class: "form-control placeholder mt-5 mb-4", placeholder: "メールアドレス"
+      = f.email_field :email, class: "form-control placeholder mt-4 mb-4", placeholder: "メールアドレス"
 
       = f.password_field :password, class: "form-control placeholder mb-3", placeholder: "パスワード"
 
       = f.label :remember_me, class: "checkbox inline mb-4" do
         = f.check_box :remember_me
-        %span.ml-1 次回から自動でログインする
+        %span.ml-1.remember-text 次回から自動でログインする
 
       = f.submit "ログイン", class: "btn btn-success btn-block mt-2"
       = link_to "パスワードをお忘れの場合", new_password_reset_path, class: "invite-text"
-      %br
-      = link_to "Twitterアカウントでログイン", '/auth/twitter'

--- a/app/views/users/new.html.haml
+++ b/app/views/users/new.html.haml
@@ -1,17 +1,19 @@
 .container
   .card.card-container
     = image_tag "logo.png", size: "200x55", class: "mx-auto"
+    = link_to  '/auth/twitter', class: "btn btn-twitter mt-4" do
+      = icon("fab", "twitter", class: "mr-1")
+      %span Twitterで登録
+    .divide-text-signup またはメールアドレスで登録
     = form_for(@user) do |f|
       = render "shared/error_messages", object: f.object
-      = f.text_field :name, class: "form-control placeholder mt-5 mb-4", placeholder: "ユーザー名"
+      = f.text_field :name, class: "form-control placeholder mt-4 mb-4", placeholder: "ユーザー名"
 
       = f.email_field :email, class: "form-control placeholder mb-4", placeholder: "メールアドレス"
 
       = f.password_field :password, class: "form-control placeholder mb-4", placeholder: "パスワード（６文字以上）"
 
-      = f.password_field :password_confirmation, class: "form-control placeholder mb-5", placeholder: "パスワード（確認のためにもう一度入力してください）"
+      = f.password_field :password_confirmation, class: "form-control placeholder", placeholder: "パスワード（確認）"
 
-      = f.submit "新規登録", class: "btn btn-primary btn-block"
+      = f.submit "新規登録", class: "btn btn-primary btn-block btn-signup mt-4"
       = link_to "すでにアカウントをお持ちの場合", login_path, class: "invite-text"
-      %br
-      = link_to "Twitteアカウントでログイン", '/auth/twitter'


### PR DESCRIPTION
close #45 

## 概要
- 新規登録ページとログインページにTwitterログインボタンを設置
- その他微調整
  - 新規登録ボタンのmargin-topをスマホでは少しする
  - remember meの文のfont-sizeをスマホ表示で小さくする

## テスト内容
- chromeの検証ツールで見た目を確認

## 参考URL
- https://terkel.jp/archives/2014/01/text-with-horizontal-line/