### PR TITLE
ログイン要求処理とフレンドリーフォワーディングの実装

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -7,7 +7,7 @@ class SessionsController < ApplicationController
     if user && user.authenticate(params[:session][:password])
       log_in user
       params[:session][:remember_me] == "1" ? remember(user) : forget(user)
-      redirect_to user
+      redirect_back_or user
       flash[:info] = "ログインしました"
     else
       flash.now[:danger] = "メールアドレスかパスワードが間違っています"

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,6 @@
 class UsersController < ApplicationController
+  before_action :logged_in_user, only: [:show]
+
   def new
     @user = User.new
   end
@@ -24,7 +26,7 @@ class UsersController < ApplicationController
     if user
       log_in user
       flash[:success] = "ログインしました"
-      redirect_to user
+      redirect_back_or user
     else
       flash[:warning] = "ログインに失敗しました"
       redirect_to new_user_path
@@ -39,5 +41,13 @@ class UsersController < ApplicationController
                 :email,
                 :password,
                 :password_confirmation)
+    end
+
+    def logged_in_user
+      unless logged_in?
+        store_location
+        flash[:warning] = "ログインしてください"
+        redirect_to login_url
+      end
     end
 end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -36,4 +36,14 @@ module SessionsHelper
     session.delete(:user_id)
     @current_user = nil
   end
+
+  # for friendly forwarding
+  def redirect_back_or(default)
+    redirect_to(session[:forwarding_url] || default)
+    session.delete(:forwarding_url)
+  end
+
+  def store_location
+    session[:forwarding_url] = request.original_url if request.get?
+  end
 end


### PR DESCRIPTION
close #28 

## 概要
- ログインしていない状態でユーザー詳細ページにアクセスできずログインページにリダイレクトされる
- ログイン要求処理でリダイレクトされた直後にログインすると、アクセスしようとしたページに遷移する

## テスト内容
- ログインしていない状態でユーザー詳細ページにアクセスしようとするとログインページにリダイレクトされることを確認
- フレンドリーフォワーディングが機能している事を確認
  - メールアドレスログインでもTwitterログインでも