### PR TITLE
ユーザー編集機能の実装

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,5 @@
 class UsersController < ApplicationController
-  before_action :check_login, only: [:index, :show]
+  before_action :check_login, only: [:index, :show, :edit, :update_profile, :update_password]
   before_action :check_admin, only: [:index]
 
   def index
@@ -19,6 +19,40 @@ class UsersController < ApplicationController
       redirect_to @user
     else
       render :new
+    end
+  end
+
+  def edit
+    @user = User.find(params[:id])
+  end
+
+  def update_profile
+    @user = User.find(params[:id])
+    before_change_email = @user.email
+    if @user.update_attributes(user_params)
+      @user.reactivate unless @user.email == before_change_email
+      flash[:success] = "プロフィールを更新しました"
+      redirect_to @user
+    else
+      render :edit
+    end
+  end
+
+  def update_password
+    @user = User.find(params[:id])
+    unless @user.authenticate(params[:user][:current_password])
+      @user.errors.add(:base, "現在のパスワードが違います")
+      render :edit and return
+    end
+    if params[:user][:password].blank?
+      @user.errors.add(:password, :blank)
+      render :edit and return
+    end
+    if @user.update_attributes(user_params)
+      flash[:success] = "パスワードを更新しました"
+      redirect_to @user
+    else
+      render :edit
     end
   end
 

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -25,6 +25,10 @@ module SessionsHelper
     !!current_user
   end
 
+  def logged_in_by_twitter?
+    current_user.provider == "twitter"
+  end
+
   def forget(user)
     user.forget
     cookies.delete(:user_id)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,7 +9,7 @@ class User < ApplicationRecord
                     format: { with: VALID_EMAIL_REGEX },
                     uniqueness: { case_sensitive: false }
   has_secure_password
-  validates :password, presence: true, length: { minimum: 6 }
+  validates :password, presence: true, length: { minimum: 6 }, allow_nil: true
 
   has_many :habits, dependent: :destroy
   has_many :makes, dependent: :destroy
@@ -66,6 +66,12 @@ class User < ApplicationRecord
 
   def send_activation_email
     UserMailer.account_activation(self).deliver_now
+  end
+
+  def reactivate
+    update_attribute(:activated, false)
+    create_activation_digest and self.save
+    send_activation_email
   end
 
   def create_reset_digest

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -1,0 +1,21 @@
+.container
+  .card.card-container
+    = form_for(@user, url: update_profile_path(params[:id])) do |f|
+      = render "shared/error_messages", object: f.object
+      = f.text_field :name, class: "form-control placeholder mt-4 mb-4", placeholder: "ユーザー名"
+
+      = f.email_field :email, class: "form-control placeholder mb-4", placeholder: "メールアドレス"
+
+      = f.submit "プロフィールを更新する", class: "btn btn-info btn-block btn-signup mt-4"
+
+.container
+  .card.card-container
+    = form_for(@user, url: update_password_path(params[:id])) do |f|
+      = render "shared/error_messages", object: f.object
+      = f.password_field :current_password, class: "form-control placeholder mb-4", placeholder: "現在のパスワード"
+
+      = f.password_field :password, class: "form-control placeholder mb-4", placeholder: "新しいパスワード（６文字以上）"
+
+      = f.password_field :password_confirmation, class: "form-control placeholder", placeholder: "新しいパスワード（確認）"
+
+      = f.submit "パスワードを更新する", class: "btn btn-info btn-block btn-signup mt-4"

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -8,3 +8,6 @@
   = "activated: #{@user.activated}"
 %p
   = "admin: #{@user.admin}"
+
+- if @user == current_user && !logged_in_by_twitter?
+  = link_to "編集", edit_user_path(@user), class: "btn btn-info"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,9 @@ Rails.application.routes.draw do
   delete 'logout', to: 'sessions#destroy'
   get '/auth/:provider/callback', to: 'users#twitter_login'
   get '/admin/users', to: 'users#index'
-  resources :users, only: [:new, :create, :show]
+  patch '/users/:id/profile', to: 'users#update_profile', as: 'update_profile'
+  patch '/users/:id/password', to: 'users#update_password', as: 'update_password'
+  resources :users, except: [:index, :update ,:destroy]
   resources :account_activations, only: [:edit]
   resources :password_resets, only: [:new, :create, :edit, :update]
 end


### PR DESCRIPTION
close #40 

## 概要
- emailが変更された場合は, `activated: false`にしてアカウント有効化メールを新しいアドレスに送信
- パスワードを入力しなくてもプロフィールが更新できるようにUserモデルのpasswordのバリデーションに`allow: nil`を追加
- パスワード変更のフォームに適切なエラーメッセージが表示されるように処理を追加
- 他人のページの閲覧と情報の更新はできないように設定
  - 管理者ユーザーも他人の情報の編集はできない
- Twitterログインしたユーザーは情報を更新できないように設定
  - emailとpasswordはダミーなのでややこしくならないように＆アカウントの名前と画像はTwitterから取得しているため

## テスト内容
- 上記の内容が適切に実装されていることをlocalhostでも本番環境でも確認

## 参考URL
- [PUTかPATCHか](https://qiita.com/necojackarc/items/fd53c96865d0ef7a02d8)
  - PUTは全部更新
  - PATCHは一部更新
- [rubyにおける空判定](https://techracho.bpsinc.jp/baba/2011_11_26/4724)