### PR TITLE
ユーザー編集ページのスタイリング

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -135,7 +135,7 @@ ul {
   @include form-divide(100px)
 }
 
-// password-reset
+// password reset
 .password-reset-wrapper {
   max-width: 800px;
   .heading {
@@ -146,6 +146,22 @@ ul {
   }
 }
 
+
+// user edit
+.user-edit-wrapper {
+  .nav-tabs.nav-justified {
+    border-bottom: none;
+  .select-edit-tab {
+    cursor: pointer;
+    color: #dee2e6;
+    border-bottom: 1px solid #dee2e6;
+    }
+    .select-edit-tab.active {
+      color: rgba(0, 0, 0, 0.7);
+      border-bottom: 1px solid rgba(0, 0, 0, 0.7);
+    }
+  }
+}
 // footer
 footer {
   height: 10vh;
@@ -219,5 +235,16 @@ footer {
   }
   .divide-text-login {
     @include form-divide(70px)
+  }
+  .user-edit-wrapper {
+    .select-edit-tab {
+      font-size: .8rem;
+    }
+    .placeholder {
+      font-size: .6rem;
+    }
+    .btn-signup {
+      font-size: .8rem;
+    }
   }
 }

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -1,21 +1,26 @@
-.container
+.container.user-edit-wrapper
   .card.card-container
-    = form_for(@user, url: update_profile_path(params[:id])) do |f|
-      = render "shared/error_messages", object: f.object
-      = f.text_field :name, class: "form-control placeholder mt-4 mb-4", placeholder: "ユーザー名"
+    %ul.nav.nav-tabs.nav-justified.text-center
+      %li.active.col-6
+        .show.active.select-edit-tab.pb-2{ "data-target" => "#profile-edit", "data-toggle" => "tab", class: "active show"} プロフィール
+      %li.col-6
+        .select-edit-tab.pb-2{ "data-target" => "#password-edit", "data-toggle" => "tab"} パスワード
+    .tab-content.tabs-profile-edit.col-12
+      #profile-edit.tab-pane.fade.active.show.in
+        = form_for(@user, url: update_profile_path(params[:id])) do |f|
+          = render "shared/error_messages", object: f.object
+          = f.text_field :name, class: "form-control placeholder mt-5 mb-4", placeholder: "ユーザー名"
 
-      = f.email_field :email, class: "form-control placeholder mb-4", placeholder: "メールアドレス"
+          = f.email_field :email, class: "form-control placeholder mb-4", placeholder: "メールアドレス"
 
-      = f.submit "プロフィールを更新する", class: "btn btn-info btn-block btn-signup mt-4"
+          = f.submit "プロフィールを更新する", class: "btn btn-info btn-block btn-signup mt-4"
+      #password-edit.tab-pane.fade.col-12
+        = form_for(@user, url: update_password_path(params[:id])) do |f|
+          = render "shared/error_messages", object: f.object
+          = f.password_field :current_password, class: "form-control placeholder mt-5 mb-4", placeholder: "現在のパスワード"
 
-.container
-  .card.card-container
-    = form_for(@user, url: update_password_path(params[:id])) do |f|
-      = render "shared/error_messages", object: f.object
-      = f.password_field :current_password, class: "form-control placeholder mb-4", placeholder: "現在のパスワード"
+          = f.password_field :password, class: "form-control placeholder mb-4", placeholder: "新しいパスワード（６文字以上）"
 
-      = f.password_field :password, class: "form-control placeholder mb-4", placeholder: "新しいパスワード（６文字以上）"
+          = f.password_field :password_confirmation, class: "form-control placeholder", placeholder: "新しいパスワード（確認）"
 
-      = f.password_field :password_confirmation, class: "form-control placeholder", placeholder: "新しいパスワード（確認）"
-
-      = f.submit "パスワードを更新する", class: "btn btn-info btn-block btn-signup mt-4"
+          = f.submit "パスワードを更新する", class: "btn btn-info btn-block btn-signup mt-4"


### PR DESCRIPTION
close #52 

## 概要
- ユーザー編集画面をスタイリング
- スマホ表示用にところどころfont-sizeをmedia queryで指定

# テスト内容
- chromeの検証ツールで表示を確認

# 参考URL
- [Bootstrapを使ったフォームテンプレート](https://bootsnipp.com/snippets/OP5nZ)