### PR TITLE
ユーザー削除機能の実装

### DIFF
--- a/app/views/users/delete.html.haml
+++ b/app/views/users/delete.html.haml
@@ -1,0 +1,4 @@
+%h1 ユーザー削除ページ
+
+%p アカウント消したらデータは復旧できません的な案内文
+= link_to "削除", user_path(@user), method: :delete, data: { confirm: "本当に削除しますか？"}

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -24,3 +24,5 @@
           = f.password_field :password_confirmation, class: "form-control placeholder", placeholder: "新しいパスワード（確認）"
 
           = f.submit "パスワードを更新する", class: "btn btn-info btn-block btn-signup mt-4"
+    - unless current_user.admin?
+      = link_to "アカウントを削除する場合はこちらから", delete_page_path(@user)

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -1,2 +1,9 @@
 %h1 ユーザー一覧（管理画面）
-  
+
+%ul
+- @users.each do |user|
+  %li
+    = "#{user.name} :"
+    = user.email
+    - unless user.admin?
+      = link_to "削除", user_path(user), method: :delete, data: { confirm: "本当に削除しますか"}

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -11,3 +11,6 @@
 
 - if @user == current_user && !logged_in_by_twitter?
   = link_to "編集", edit_user_path(@user), class: "btn btn-info"
+
+- if @user == current_user && logged_in_by_twitter?
+  = link_to "アカウントを削除する場合はこちらから", delete_page_path(@user)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,8 @@ Rails.application.routes.draw do
   get '/admin/users', to: 'users#index'
   patch '/users/:id/profile', to: 'users#update_profile', as: 'update_profile'
   patch '/users/:id/password', to: 'users#update_password', as: 'update_password'
-  resources :users, except: [:index, :update ,:destroy]
+  get '/users/:id/delete', to: 'users#delete', as: 'delete_page'
+  resources :users, except: [:index, :update]
   resources :account_activations, only: [:edit]
   resources :password_resets, only: [:new, :create, :edit, :update]
 end


### PR DESCRIPTION
close #41 

## 概要
- ユーザー削除ページとユーザー削除機能の作成
- ユーザー削除ページは自分しかアクセスできない
- ユーザー削除機能は自分か管理ユーザーしか実行できない
- 管理ユーザーのことは削除することができない
- ユーザー管理ページにユーザー一覧と各ユーザーの削除ボタンを設置

## テスト内容
- 自分のことを削除できることを確認
- 他人の削除ページにアクセスできないことを確認
- 管理ユーザー以外のユーザーは他人を削除できないことを確認
- 管理ユーザーは他人を削除できないことを確認
- 管理ユーザーのことは削除できないことを確認（自分でも）

## 補足
- ユーザーを削除した直後はまだsession[:user_id]には値が残っているから、自分を削除した場合でもcurrent_userで情報を取得できる