### PR TITLE
ユーザー管理ページのスタイリング

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,9 @@ gem 'font-awesome-sass', '~> 5.6.1'
 gem 'omniauth'
 gem 'omniauth-twitter'
 
+# pagination
+gem 'kaminari'
+
 group :development, :test do
   gem 'pry-rails'
   gem 'pry-byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,6 +124,18 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    kaminari (1.1.1)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.1.1)
+      kaminari-activerecord (= 1.1.1)
+      kaminari-core (= 1.1.1)
+    kaminari-actionview (1.1.1)
+      actionview
+      kaminari-core (= 1.1.1)
+    kaminari-activerecord (1.1.1)
+      activerecord
+      kaminari-core (= 1.1.1)
+    kaminari-core (1.1.1)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -278,6 +290,7 @@ DEPENDENCIES
   haml-rails
   jbuilder (~> 2.5)
   jquery-rails
+  kaminari
   listen (>= 3.0.5, < 3.2)
   omniauth
   omniauth-twitter

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -184,6 +184,29 @@ ul {
   }
 }
 
+// user index
+.user-index-wrapper {
+  width: 100%;
+  padding: .5rem;
+  table {
+    table-layout: fixed;
+  }
+  .user-id {
+    width: 10vw;
+  }
+  .user-name {
+    width: 20vw;
+    overflow: scroll;
+  }
+  .user-email {
+    width: 50vw;
+    overflow: scroll;
+  }
+  .user-delete {
+    width: 10vw;
+  }
+}
+
 // footer
 footer {
   height: 10vh;
@@ -277,6 +300,14 @@ footer {
     }
     a {
       font-size: .8rem;
+    }
+  }
+  .user-index-wrapper {
+    h1 {
+      font-size: 1.8rem;
+    }
+    th {
+      font-size: .68rem;
     }
   }
 }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,7 +6,7 @@ class UsersController < ApplicationController
   before_action :check_destroy, only: [:destroy]
 
   def index
-    @users = User.all.order(id: :asc)
+    @users = User.order(id: :asc).page(params[:page])
   end
 
   def new

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,7 +6,7 @@ class UsersController < ApplicationController
   before_action :check_destroy, only: [:destroy]
 
   def index
-    @users = User.all
+    @users = User.all.order(id: :asc)
   end
 
   def new

--- a/app/views/kaminari/_first_page.html.haml
+++ b/app/views/kaminari/_first_page.html.haml
@@ -1,0 +1,2 @@
+%li.page-item
+  = link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, remote: remote, class: 'page-link'

--- a/app/views/kaminari/_gap.html.haml
+++ b/app/views/kaminari/_gap.html.haml
@@ -1,0 +1,2 @@
+%li.page-item.disabled
+  = link_to raw(t 'views.pagination.truncate'), '#', class: 'page-link'

--- a/app/views/kaminari/_last_page.html.haml
+++ b/app/views/kaminari/_last_page.html.haml
@@ -1,0 +1,2 @@
+%li.page-item
+  = link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, remote: remote, class: 'page-link'

--- a/app/views/kaminari/_next_page.html.haml
+++ b/app/views/kaminari/_next_page.html.haml
@@ -1,0 +1,2 @@
+%li.page-item
+  = link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, rel: 'next', remote: remote, class: 'page-link'

--- a/app/views/kaminari/_page.html.haml
+++ b/app/views/kaminari/_page.html.haml
@@ -1,0 +1,6 @@
+- if page.current?
+  %li.page-item.active
+    = content_tag :a, page, data: { remote: remote }, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil)), class: 'page-link'
+- else
+  %li.page-item
+    = link_to page, url, remote: remote, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil)), class: 'page-link'

--- a/app/views/kaminari/_paginator.html.haml
+++ b/app/views/kaminari/_paginator.html.haml
@@ -1,0 +1,13 @@
+= paginator.render do
+  .my-4
+    %nav
+      %ul.pagination.justify-content-center
+        = first_page_tag unless current_page.first?
+        = prev_page_tag unless current_page.first?
+        - each_page do |page|
+          - if page.left_outer? || page.right_outer? || page.inside_window?
+            = page_tag page
+          - elsif !page.was_truncated?
+            = gap_tag
+        = next_page_tag unless current_page.last?
+        = last_page_tag unless current_page.last?

--- a/app/views/kaminari/_prev_page.html.haml
+++ b/app/views/kaminari/_prev_page.html.haml
@@ -1,0 +1,2 @@
+%li.page-item
+  = link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, rel: 'prev', remote: remote, class: 'page-link'

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -1,9 +1,22 @@
-%h1 ユーザー一覧（管理画面）
-
-%ul
-- @users.each do |user|
-  %li
-    = "#{user.name} :"
-    = user.email
-    - unless user.admin?
-      = link_to "削除", user_path(user), method: :delete, data: { confirm: "本当に削除しますか"}
+.user-index-wrapper
+  %h1.text-center.my-5 ユーザー一覧
+  %table.table.table-bordered.table-striped
+    %thead
+      %th.user-id<
+        = User.human_attribute_name :id
+      %th.user-name<
+        = User.human_attribute_name :name
+      %th.user-email<
+        = User.human_attribute_name :email
+      %th.user-delete<
+    - @users.each do |user|
+      %tr
+        %td.user-id<
+          = user.id
+        %td.user-name<
+          = user.name
+        %td.user-email<
+          = user.email
+        %td.user-delete<
+          - unless user.admin?
+            = link_to "削除", user_path(user), method: :delete, data: { confirm: "本当に削除しますか？" }

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -20,3 +20,4 @@
         %td.user-delete<
           - unless user.admin?
             = link_to "削除", user_path(user), method: :delete, data: { confirm: "本当に削除しますか？" }
+  = paginate @users

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -14,3 +14,6 @@
 
 - if @user == current_user && logged_in_by_twitter?
   = link_to "アカウントを削除する場合はこちらから", delete_page_path(@user)
+
+- if @user == current_user && @user.admin?
+  = link_to "ユーザー管理画面", admin_users_path, class: "btn btn-success"

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+Kaminari.configure do |config|
+  config.default_per_page = 20
+  # config.max_per_page = nil
+  # config.window = 4
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.params_on_first_page = false
+end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -237,3 +237,10 @@ ja:
       long: "%Y/%m/%d %H:%M"
       short: "%m/%d %H:%M"
     pm: 午後
+  views:
+    paination:
+      first: "最初へ"
+      last: "最後へ"
+      previous: "前へ"
+      next: "次へ"
+      truncate: "..."

--- a/config/locales/kaminari_ja.yml
+++ b/config/locales/kaminari_ja.yml
@@ -1,0 +1,8 @@
+ja:
+  views:
+    pagination:
+      first: "&laquo; 最初"
+      last: "最後 &raquo;"
+      previous: "&lsaquo; 前"
+      next: "次 &rsaquo;"
+      truncate: "&hellip;"

--- a/db/seeds/development.rb
+++ b/db/seeds/development.rb
@@ -11,3 +11,11 @@ User.create(
   email: "john@ne.jp",
   password: "foobar",
 )
+
+50.times do |i|
+  User.create(
+    name: "hoge",
+    email: "test#{i}@ne.jp",
+    password: "foobar"
+  )
+end


### PR DESCRIPTION
close #47 

## 概要
- ユーザー一覧の表示
  - id, name, emailと管理ユーザー以外の削除リンク
- ページネーションの実装（kaminari）
  - デフォルトの表示数を20に変更
  - 日本語表示に設定

## テスト内容
- 削除リンクでユーザーを正常に削除できることを確認
- 長いnameやemailの場合、テーブル自体は画面幅以上に広がらずにセル内でスクロールされることを確認
- 日本語表示を含めページネーションがきちんと実装されていることを確認

## 参考URL
- [テーブルのスタイリング](http://www.htmq.com/style/table-layout.shtml)
- [ページネーションのスタイリング](https://v4-alpha.getbootstrap.com/components/pagination/)
- [モデル名の翻訳へのアクセスのしかた](https://qiita.com/yshr04hrk/items/cb7b81c104321f660661)
- kaminari系
  - https://github.com/kaminari/kaminari#install
  - https://www.yuta-u.com/programing/rails/rails-kaminari#toc2
  - https://www.d-wood.com/blog/2018/01/31_9456.html
  - https://wonderwall.hatenablog.com/entry/2015/08/09/094130
