### PR TITLE
rubocopの自動修正で直らなかった部分の修正

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,3 +9,8 @@ inherit_gem:
 AllCops:
   TargetRubyVersion: 2.5
   TargetRailsVersion: 5.1
+  Exclude:
+    - "vendor/**/*" # rubocopで元々指定されていたファイル
+    - "db/schema*.rb"
+    - "node_modules/**/*"
+    - "db/migrate/**/*"

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -34,7 +34,7 @@ class PasswordResetsController < ApplicationController
       render :edit
     elsif @user.update(user_params)
       log_in @user
-      @user.update_attribute(:reset_digest, nil)
+      @user.update_attribute(:reset_digest, nil) # rubocop:disable Rails/SkipsModelValidations
       flash[:success] = "パスワードを更新しました"
       redirect_to @user
     else

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,4 @@
-class UsersController < ApplicationController
+class UsersController < ApplicationController # rubocop:disable Metrics/ClassLength
   before_action :check_login, only: [:index, :show, :edit, :update_profile, :update_password, :delete, :destroy]
   before_action :forbid_twitter_login_user, only: [:edit, :update_profile, :update_password]
   before_action :check_correct_user, only: [:show, :edit, :update_profile, :update_password, :delete]

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,8 +17,11 @@ class User < ApplicationRecord
 
   # ハッシュ値を返す
   def self.digest(string)
-    cost = ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST :
-                                                  BCrypt::Engine.cost
+    cost = if ActiveModel::SecurePassword.min_cost
+             BCrypt::Engine::MIN_COST
+           else
+             BCrypt::Engine.cost
+           end
     BCrypt::Password.create(string, cost: cost)
   end
 
@@ -47,7 +50,7 @@ class User < ApplicationRecord
 
   def remember
     self.remember_token = User.new_token
-    update_attribute(:remember_digest, User.digest(remember_token))
+    update_attribute(:remember_digest, User.digest(remember_token)) # rubocop:disable Rails/SkipsModelValidations
   end
 
   def authenticated?(attribute, token)
@@ -58,11 +61,11 @@ class User < ApplicationRecord
   end
 
   def forget
-    update_attribute(:remember_digest, nil)
+    update_attribute(:remember_digest, nil) # rubocop:disable Rails/SkipsModelValidations
   end
 
   def activate
-    update_attribute(:activated, true)
+    update_attribute(:activated, true) # rubocop:disable Rails/SkipsModelValidations
   end
 
   def send_activation_email
@@ -70,14 +73,14 @@ class User < ApplicationRecord
   end
 
   def reactivate
-    update_attribute(:activated, false)
+    update_attribute(:activated, false) # rubocop:disable Rails/SkipsModelValidations
     create_activation_digest and self.save
     send_activation_email
   end
 
   def create_reset_digest
     self.reset_token = User.new_token
-    update_columns(reset_digest: User.digest(reset_token), reset_sent_at: Time.zone.now)
+    update_columns(reset_digest: User.digest(reset_token), reset_sent_at: Time.zone.now) # rubocop:disable Rails/SkipsModelValidations
   end
 
   def send_password_reset_email


### PR DESCRIPTION
close #68 

## 概要
- `.rubocop.yml`にrubocopのチェックをしないファイルの記述
- `User.digest`メソッドはrubocopの警告にしたがって修正
  - 三項演算子は改行して使わない
  - 条件分岐で変数の値を変える場合は返り値で代入する
- 他の警告に関してはコメントでrubocopのチェックをスキップするようにして対応
  - クラス名の長さ(Railsの命名規則に則っているため)とバリデーションのスキップの禁止（意図的にバリデーションをスキップさせているため）

## テスト内容
- rubocopの警告が出なくなったことを確認
- `User.digest`メソッドが正常に機能することを確認

## 参考URL
- [一部のコードだけrubocopの警告を無視する](https://morizyun.github.io/ruby/rails-tips-miscellaneous.html)
- https://qiita.com/yuta-ushijima/items/4bd1b6a6d93b596ae3f3