### PR TITLE
【WIP】自分ルール（新しい習慣）作成機能の実装

### DIFF
--- a/app/assets/javascripts/habits.coffee
+++ b/app/assets/javascripts/habits.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/makes.coffee
+++ b/app/assets/javascripts/makes.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/habits.scss
+++ b/app/assets/stylesheets/habits.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the habits controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/makes.scss
+++ b/app/assets/stylesheets/makes.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the makes controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,13 @@
 class ApplicationController < ActionController::Base
   include SessionsHelper
+
+  private
+
+    def check_login
+      unless logged_in?
+        store_location
+        flash[:warning] = "ログインしてください"
+        redirect_to login_url
+      end
+    end
 end

--- a/app/controllers/habits_controller.rb
+++ b/app/controllers/habits_controller.rb
@@ -1,0 +1,6 @@
+class HabitsController < ApplicationController
+  before_action :check_login
+
+  def select
+  end
+end

--- a/app/controllers/makes_controller.rb
+++ b/app/controllers/makes_controller.rb
@@ -1,0 +1,44 @@
+class MakesController < ApplicationController
+  before_action :check_login
+
+  def new1
+  end
+
+  def new2
+    @title = params[:make][:title]
+    # 文字数判定はフォーム側でやる
+  end
+
+  def new3
+    @title = params[:make][:title]
+    @norm = params[:make][:norm]
+  end
+
+  def new4
+    @title = params[:make][:title]
+    @rule1 = params[:make][:rule1]
+  end
+
+  def new5
+    @title = params[:make][:title]
+    @rule1 = params[:make][:rule1]
+    @situation = params[:make][:situation]
+  end
+
+  def create
+    make = current_user.makes.build(make_params)
+    if make.save
+      flash[:success] = "自分ルールを作成しました！"
+      redirect_to current_user
+    else
+      flash[:warning] = "データの保存に失敗しました。お手数ですがもう一度やり直してください。"
+      redirect_to makes_new_1_url
+    end
+  end
+
+  private
+
+    def make_params
+      params.require(:make).permit(:title, :rule1, :rule2)
+    end
+end

--- a/app/controllers/makes_controller.rb
+++ b/app/controllers/makes_controller.rb
@@ -1,27 +1,23 @@
 class MakesController < ApplicationController
   before_action :check_login
+  before_action :forbid_direct_access, except: [:new1]
+  before_action :set_title, only: [:new2, :new3, :new4, :new5]
+  before_action :set_rule1, only: [:new4, :new5]
 
   def new1
   end
 
   def new2
-    @title = params[:make][:title]
-    # 文字数判定はフォーム側でやる
   end
 
   def new3
-    @title = params[:make][:title]
     @norm = params[:make][:norm]
   end
 
   def new4
-    @title = params[:make][:title]
-    @rule1 = params[:make][:rule1]
   end
 
   def new5
-    @title = params[:make][:title]
-    @rule1 = params[:make][:rule1]
     @situation = params[:make][:situation]
   end
 
@@ -40,5 +36,17 @@ class MakesController < ApplicationController
 
     def make_params
       params.require(:make).permit(:title, :rule1, :rule2)
+    end
+
+    def forbid_direct_access
+      redirect_to makes_new_1_path if request.referer.nil?
+    end
+
+    def set_title
+      @title = params[:make][:title]
+    end
+
+    def set_rule1
+      @rule1 = params[:make][:rule1]
     end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -102,14 +102,6 @@ class UsersController < ApplicationController # rubocop:disable Metrics/ClassLen
                :password_confirmation)
     end
 
-    def check_login
-      unless logged_in?
-        store_location
-        flash[:warning] = "ログインしてください"
-        redirect_to login_url
-      end
-    end
-
     def forbid_twitter_login_user
       redirect_to(current_user) if current_user.provider == "twitter"
     end

--- a/app/helpers/habits_helper.rb
+++ b/app/helpers/habits_helper.rb
@@ -1,0 +1,2 @@
+module HabitsHelper
+end

--- a/app/helpers/makes_helper.rb
+++ b/app/helpers/makes_helper.rb
@@ -1,0 +1,2 @@
+module MakesHelper
+end

--- a/app/views/habits/select.html.haml
+++ b/app/views/habits/select.html.haml
@@ -1,0 +1,5 @@
+.container
+  %h1 習慣作成（仮）
+
+  = link_to "作りたい習慣がある", makes_new_1_path, class: "btn btn-info"
+  = link_to "やめたい習慣がある", "#", class: "btn btn-warning"

--- a/app/views/makes/new1.html.haml
+++ b/app/views/makes/new1.html.haml
@@ -1,0 +1,8 @@
+.container
+  %p
+    作りたい習慣はなんですか？
+
+  = form_for(:make, url: makes_new_2_path, method: :get) do |f|
+    = f.text_area :title, required: true, maxlength: 255, class: "form-control", placeholder: "例） 運動"
+
+    = f.submit "次へ", class: "btn btn-info"

--- a/app/views/makes/new2.html.haml
+++ b/app/views/makes/new2.html.haml
@@ -10,4 +10,3 @@
 
     = link_to "戻る", "#", onclick: "history.back()", class: "btn btn-warning"
     = f.submit "次へ", class: "btn btn-info"
-    

--- a/app/views/makes/new2.html.haml
+++ b/app/views/makes/new2.html.haml
@@ -1,0 +1,12 @@
+.container
+  %p
+    まずは１回のノルマを決めましょう
+  %p
+    最初はバカバカしいほど簡単なことから始めることがコツです
+
+  = form_for(:make, url: makes_new_3_path, method: :get) do |f|
+    = f.hidden_field :title, value: @title
+    = f.text_area :norm, required: true, maxlength: 150, class: "form-control", placeholder: "１回腕立て伏せをする"
+
+    = f.submit "次へ", class: "btn btn-info"
+    

--- a/app/views/makes/new2.html.haml
+++ b/app/views/makes/new2.html.haml
@@ -8,5 +8,6 @@
     = f.hidden_field :title, value: @title
     = f.text_area :norm, required: true, maxlength: 150, class: "form-control", placeholder: "１回腕立て伏せをする"
 
+    = link_to "戻る", "#", onclick: "history.back()", class: "btn btn-warning"
     = f.submit "次へ", class: "btn btn-info"
     

--- a/app/views/makes/new3.html.haml
+++ b/app/views/makes/new3.html.haml
@@ -1,0 +1,11 @@
+.container
+  %p
+    すでにある習慣をノルマを結びつけて１つ目のルールを作ります
+  %p
+    「〜をしたら、ノルマを行う」という形で作ってみましょう。
+
+  = form_for(:make, url: makes_new_4_path, method: :get) do |f|
+    = f.hidden_field :title, value: @title
+    = f.text_area :rule1, required: true, maxlength: 255, class: "form-control", value: "〜をしたら、#{@norm}をする"
+
+    = f.submit "次へ", class: "btn btn-info"

--- a/app/views/makes/new3.html.haml
+++ b/app/views/makes/new3.html.haml
@@ -6,6 +6,7 @@
 
   = form_for(:make, url: makes_new_4_path, method: :get) do |f|
     = f.hidden_field :title, value: @title
-    = f.text_area :rule1, required: true, maxlength: 255, class: "form-control", value: "〜をしたら、#{@norm}をする"
+    = f.text_area :rule1, required: true, maxlength: 255, class: "form-control", value: "〜をしたら、#{@norm}"
 
+    = link_to "戻る", "#", onclick: "history.back()", class: "btn btn-warning"
     = f.submit "次へ", class: "btn btn-info"

--- a/app/views/makes/new4.html.haml
+++ b/app/views/makes/new4.html.haml
@@ -1,0 +1,12 @@
+.container
+  %p
+    ２つ目の自分ルールを作ります
+  %p
+    挫折しそうになる状況を想像してみてください
+
+  = form_for(:make, url: makes_new_5_path, method: :get) do |f|
+    = f.hidden_field :title, value: @title
+    = f.hidden_field :rule1, value: @rule1
+    = f.text_area :situation, required: true, maxlength: 150, class: "form-control", placeholder: "疲れて眠い"
+
+    = f.submit "次へ", class: "btn btn-info"

--- a/app/views/makes/new4.html.haml
+++ b/app/views/makes/new4.html.haml
@@ -9,4 +9,5 @@
     = f.hidden_field :rule1, value: @rule1
     = f.text_area :situation, required: true, maxlength: 150, class: "form-control", placeholder: "疲れて眠い"
 
+    = link_to "戻る", "#", onclick: "history.back()", class: "btn btn-warning"
     = f.submit "次へ", class: "btn btn-info"

--- a/app/views/makes/new5.html.haml
+++ b/app/views/makes/new5.html.haml
@@ -8,4 +8,6 @@
     = f.hidden_field :title, value: @title
     = f.hidden_field :rule1, value: @rule1
     = f.text_area :rule2, required: true, maxlength: 255, class: "form-control", value: "#{@situation}になったら〜をする"
+
+    = link_to "戻る", "#", onclick: "history.back()", class: "btn btn-warning"
     = f.submit "次へ", class: "btn btn-info"

--- a/app/views/makes/new5.html.haml
+++ b/app/views/makes/new5.html.haml
@@ -1,0 +1,11 @@
+.container
+  %p
+    挫折しそうな状況になった時の対策を考えましょう
+  %p
+    どのような行動や考え方をしますか？
+
+  = form_for(:make, url: makes_path) do |f|
+    = f.hidden_field :title, value: @title
+    = f.hidden_field :rule1, value: @rule1
+    = f.text_area :rule2, required: true, maxlength: 255, class: "form-control", value: "#{@situation}になったら〜をする"
+    = f.submit "次へ", class: "btn btn-info"

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -9,6 +9,8 @@
 %p
   = "admin: #{@user.admin}"
 
+= link_to "自分ルールを作る", habits_select_path, class: "btn btn-primary"
+
 - if @user == current_user && !logged_in_by_twitter?
   = link_to "編集", edit_user_path(@user), class: "btn btn-info"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,15 +1,27 @@
 Rails.application.routes.draw do
   root "static_pages#home"
-  get "/signup", to: "users#new"
+
   get "/login", to: "sessions#new"
   post "/login", to: "sessions#create"
   delete "logout", to: "sessions#destroy"
+
+  get "/signup", to: "users#new"
   get "/auth/:provider/callback", to: "users#twitter_login"
   get "/admin/users", to: "users#index"
   patch "/users/:id/profile", to: "users#update_profile", as: "update_profile"
   patch "/users/:id/password", to: "users#update_password", as: "update_password"
   get "/users/:id/delete", to: "users#delete", as: "delete_page"
   resources :users, except: [:index, :update]
+
   resources :account_activations, only: [:edit]
   resources :password_resets, only: [:new, :create, :edit, :update]
+
+  get "/habits/select", to: "habits#select"
+
+  get "/makes/new/1", to: "makes#new1"
+  get "/makes/new/2", to: "makes#new2"
+  get "/makes/new/3", to: "makes#new3"
+  get "/makes/new/4", to: "makes#new4"
+  get "/makes/new/5", to: "makes#new5"
+  resources :makes, only: [:create]
 end

--- a/test/controllers/habits_controller_test.rb
+++ b/test/controllers/habits_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class HabitsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/controllers/makes_controller_test.rb
+++ b/test/controllers/makes_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class MakesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
close #70 

## 概要
- check_loginをapplication_controllerに移動
   - 複数のコントローラーで使うため
-新しい習慣のための自分ルール（make）の作成までは仮のビューで実装
- 戻るボタンはブラウザバックと同じ挙動で実装
  - redirectで実装するとparamsが受け取れないため
   - `link_to "戻る", "#", onclick: "history.back()"`でブラウザバックと同じ挙動をする
- 作成の途中の画面へのURLの直打ちでのアクセスを弾く
  - paramsを渡さないでアクセスしてもエラーになってしまうため
  - `request.referer`を使えば実装できる

## テスト内容
- ログインしていない状態ではhabits/makesのページにアクセスできないことを確認
- ブラウザ上でmakeを作成できることを確認
- `/makes/new/2~5`へURLの直打ちでアクセスできないことを確認

## 参考URL
- [インプットタグ内で文字数制限できる](https://qiita.com/oh_rusty_nail/items/e08f6b323d526fab3d55)
- [f.hidden_fieldに値をいれるやり方](https://qiita.com/azusanakano/items/5849a7ca74be58d195b7)
- [request.refererについて](https://teratail.com/questions/18765)
- [link_toヘルパーでJavaScriptの処理を実行する](https://stackoverflow.com/questions/14324919/status-of-rails-link-to-function-deprecation)