### PR TITLE
フォームで文字数制限をする

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,7 +9,7 @@ class User < ApplicationRecord
                     format: { with: VALID_EMAIL_REGEX },
                     uniqueness: { case_sensitive: false }
   has_secure_password
-  validates :password, presence: true, length: { minimum: 6 }, allow_nil: true
+  validates :password, presence: true, length: { in: 6..50 }, allow_nil: true
 
   has_many :habits, dependent: :destroy
   has_many :makes, dependent: :destroy

--- a/app/views/password_resets/edit.html.haml
+++ b/app/views/password_resets/edit.html.haml
@@ -10,8 +10,8 @@
 
         = hidden_field_tag :email, @user.email
 
-        = f.password_field :password, class: "form-control placeholder my-4", placeholder: "パスワード（６文字以上）"
+        = f.password_field :password, required: true, maxlength: 50, class: "form-control placeholder my-4", placeholder: "パスワード（６文字以上）"
 
-        = f.password_field :password_confirmation, class: "form-control placeholder mb-4", placeholder: "パスワード（確認）"
+        = f.password_field :password_confirmation, required: true, maxlength: 50, class: "form-control placeholder mb-4", placeholder: "パスワード（確認）"
 
         = f.submit "パスワードを変更する", class: "btn btn-primary"

--- a/app/views/password_resets/new.html.haml
+++ b/app/views/password_resets/new.html.haml
@@ -8,7 +8,7 @@
       %p
         パスワード変更ページのURLを記載したメールを送信します。
       = form_for(:password_reset, url: password_resets_path) do |f|
-        = f.email_field :email, class: "form-control placeholder mt-3", placeholder: "メールアドレス"
+        = f.email_field :email, required: true, class: "form-control placeholder mt-3", placeholder: "メールアドレス"
         %div
           = f.submit "メールを送信する", class: "btn btn-secondary mt-4"
         = link_to "ログインはこちら", login_path, class: "invite-text display-block"

--- a/app/views/sessions/new.html.haml
+++ b/app/views/sessions/new.html.haml
@@ -6,9 +6,9 @@
       %span Twitterでログイン
     .divide-text-login または
     = form_for(:session, url: login_path) do |f|
-      = f.email_field :email, class: "form-control placeholder mt-4 mb-4", placeholder: "メールアドレス"
+      = f.email_field :email, required: true, class: "form-control placeholder mt-4 mb-4", placeholder: "メールアドレス"
 
-      = f.password_field :password, class: "form-control placeholder mb-3", placeholder: "パスワード"
+      = f.password_field :password, required: true, class: "form-control placeholder mb-3", placeholder: "パスワード"
 
       = f.label :remember_me, class: "checkbox inline mb-4" do
         = f.check_box :remember_me

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -9,19 +9,19 @@
       #profile-edit.tab-pane.fade.active.show.in
         = form_for(@user, url: update_profile_path(params[:id])) do |f|
           = render "shared/error_messages", object: f.object
-          = f.text_field :name, class: "form-control placeholder mt-5 mb-4", placeholder: "ユーザー名"
+          = f.text_field :name, required: true, maxlength: 50, class: "form-control placeholder mt-5 mb-4", placeholder: "ユーザー名"
 
-          = f.email_field :email, class: "form-control placeholder mb-4", placeholder: "メールアドレス"
+          = f.email_field :email, required: true, maxlength: 255, class: "form-control placeholder mb-4", placeholder: "メールアドレス"
 
           = f.submit "プロフィールを更新する", class: "btn btn-info btn-block btn-signup mt-4"
       #password-edit.tab-pane.fade.col-12
         = form_for(@user, url: update_password_path(params[:id])) do |f|
           = render "shared/error_messages", object: f.object
-          = f.password_field :current_password, class: "form-control placeholder mt-5 mb-4", placeholder: "現在のパスワード"
+          = f.password_field :current_password, required: true, class: "form-control placeholder mt-5 mb-4", placeholder: "現在のパスワード"
 
-          = f.password_field :password, class: "form-control placeholder mb-4", placeholder: "新しいパスワード（６文字以上）"
+          = f.password_field :password, required: true, maxlength: 50, class: "form-control placeholder mb-4", placeholder: "新しいパスワード（６文字以上）"
 
-          = f.password_field :password_confirmation, class: "form-control placeholder", placeholder: "新しいパスワード（確認）"
+          = f.password_field :password_confirmation, required: true, maxlength: 50, class: "form-control placeholder", placeholder: "新しいパスワード（確認）"
 
           = f.submit "パスワードを更新する", class: "btn btn-info btn-block btn-signup mt-4"
   = link_to "アカウントを削除する場合はこちらから", delete_page_path(@user), class: "invite-text invite-delete text-center"

--- a/app/views/users/new.html.haml
+++ b/app/views/users/new.html.haml
@@ -7,13 +7,13 @@
     .divide-text-signup またはメールアドレスで登録
     = form_for(@user) do |f|
       = render "shared/error_messages", object: f.object
-      = f.text_field :name, class: "form-control placeholder mt-4 mb-4", placeholder: "ユーザー名"
+      = f.text_field :name, required: true, maxlength: 50, class: "form-control placeholder mt-4 mb-4", placeholder: "ユーザー名"
 
-      = f.email_field :email, class: "form-control placeholder mb-4", placeholder: "メールアドレス"
+      = f.email_field :email, required: true, maxlength: 255, class: "form-control placeholder mb-4", placeholder: "メールアドレス"
 
-      = f.password_field :password, class: "form-control placeholder mb-4", placeholder: "パスワード（６文字以上）"
+      = f.password_field :password, required: true, maxlength: 50, class: "form-control placeholder mb-4", placeholder: "パスワード（６文字以上）"
 
-      = f.password_field :password_confirmation, class: "form-control placeholder", placeholder: "パスワード（確認）"
+      = f.password_field :password_confirmation, required: true, maxlength: 50, class: "form-control placeholder", placeholder: "パスワード（確認）"
 
       = f.submit "新規登録", class: "btn btn-primary btn-block btn-signup mt-4"
       = link_to "すでにアカウントをお持ちの場合", login_path, class: "invite-text"


### PR DESCRIPTION
close #71 

## 概要
- 入力必須のフォームに`required: true`を指定する
- 新たにデータを作成する場合、モデルのバリデーションに引っかかる文字数は入力できないようにする
- パスワードの文字数に最長制限を追加

## テスト内容
- ブラウザ上で指定した制限が実装されていることを確認
 
## 参考URL
- https://qiita.com/oh_rusty_nail/items/e08f6b323d526fab3d55