### PR TITLE
ログイン中のユーザーはログインページと新規登録ページに行けないようにする

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,4 +10,11 @@ class ApplicationController < ActionController::Base
         redirect_to login_url
       end
     end
+
+    def forbid_login_user
+      if logged_in?
+        flash[:warning] = "すでにログインしています"
+        redirect_to current_user
+      end
+    end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,4 +1,6 @@
 class SessionsController < ApplicationController
+  before_action :forbid_login_user, only: [:new, :create]
+
   def new
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,6 @@
 class UsersController < ApplicationController # rubocop:disable Metrics/ClassLength
   before_action :check_login, only: [:index, :show, :edit, :update_profile, :update_password, :delete, :destroy]
+  before_action :forbid_login_user, only: [:new, :create]
   before_action :forbid_twitter_login_user, only: [:edit, :update_profile, :update_password]
   before_action :check_correct_user, only: [:show, :edit, :update_profile, :update_password, :delete]
   before_action :check_admin, only: [:index]

--- a/test/controllers/quits_controller_test.rb
+++ b/test/controllers/quits_controller_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 class QuitsControllerTest < ActionDispatch::IntegrationTest
   # test "the truth" do


### PR DESCRIPTION
close #64 

## 概要
- ログインユーザーが新規登録、ログインできないようにする

## テスト内容
- ログインユーザーが新規登録ページとログインページにアクセスしようとするとマイページにリダイレクトされることを確認