### PR TITLE
ログイン中はヘッダーロゴのリンク先をマイページにする

### DIFF
--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -1,7 +1,7 @@
 %header
   %nav.navbar.navbar-expand-md.navbar-light.bg-light.sticky-top
     .container-fluid
-      %a.navbar-brand{href: "/"}
+      %a.navbar-brand{href: "#{logged_in? ? user_path(current_user) : '/'}"}
         = image_tag "logo.png", size: "170x50"
       %button.navbar-toggler{type: "button", "data-toggle" => "collapse", "data-target" => "#navbarResponsive"}
         %span.navbar-toggler-icon


### PR DESCRIPTION
close #63 

## 概要
- ヘッダーロゴのリンク先をログイン中はマイページに変更する

## テスト内容
- ログイン中にヘッダーロゴをクリックするとマイページに遷移することを確認
- 非ログイン時にヘッダーロゴをクリックするとトップページに遷移することを確認

## 参考URL
- [hamlでinlineでif文を書く](https://gist.github.com/machida/5954444)