### PR TITLE
やめたい習慣のための自分ルール作成ページのスタイリング

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -248,8 +248,8 @@ ul {
   }
 }
 
-// makes new
-.makes-new-wrapper {
+// makes new, quits new
+.makes-new-wrapper, .quits-new-wrapper {
   .jumbotron {
     background-color: #f8f8f8;
     box-shadow: 0 3px 3px rgba(0, 0, 0, 0.3);
@@ -393,7 +393,7 @@ footer {
       margin: 2rem 0!important;
     }
   }
-  .makes-new-wrapper {
+  .makes-new-wrapper, .quits-new-wrapper {
     .lead {
       font-size: 1rem;
     }
@@ -407,9 +407,12 @@ footer {
       padding: 4rem 1rem;
     }
   }
-  .makes-new-wrapper {
+  .makes-new-wrapper, .quits-new-wrapper {
     .form-control, .btn{
       width: 100%;
+    }
+    .lead {
+      text-align: justify!important;
     }
   }
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -259,7 +259,7 @@ ul {
   .lead {
     font-size: 1.5rem;
     line-height: 3.5rem;
-    letter-spacing: .15rem;
+    letter-spacing: .1rem;
   }
   .form-control {
     width: 75%;
@@ -273,6 +273,9 @@ ul {
   }
   .btn {
     width: 25%;
+  }
+  ::placeholder {
+    color: rgba(134, 164, 164, 0.7);
   }
 }
 
@@ -413,6 +416,7 @@ footer {
     }
     .lead {
       text-align: justify!important;
+      letter-spacing: .05rem;
     }
   }
 }

--- a/app/controllers/quits_controller.rb
+++ b/app/controllers/quits_controller.rb
@@ -1,7 +1,8 @@
 class QuitsController < ApplicationController
   before_action :check_login
   before_action :forbid_direct_access, except: [:new1]
-  before_action :set_title, only: [:new2, :new3, :new4]
+  before_action :set_title, only: [:new2, :new3, :new4, :new5, :new6, :new7]
+  before_action :set_rule1, only: [:new6, :new7]
 
   def new1
   end
@@ -10,11 +11,20 @@ class QuitsController < ApplicationController
   end
 
   def new3
-    @situation = params[:quit][:situation]
   end
 
   def new4
-    @rule1 = params[:quit][:rule1]
+    @situation = params[:quit][:situation]
+  end
+
+  def new5
+    @situation = params[:quit][:situation]
+  end
+
+  def new6
+  end
+
+  def new7
   end
 
   def create
@@ -40,5 +50,9 @@ class QuitsController < ApplicationController
 
     def set_title
       @title = params[:quit][:title]
+    end
+
+    def set_rule1
+      @rule1 = params[:quit][:rule1]
     end
 end

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -9,6 +9,8 @@
         %ul.navbar-nav.ml-auto
           - if logged_in?
             %li.nav-item
+              = link_to "自分ルールを作成する", habits_select_path, class: "nav-link"
+            %li.nav-item
               = link_to "マイページ", current_user, class: "nav-link"
             %li.nav-item
               = link_to "ログアウト", logout_path, method: "delete", class: "nav-link"

--- a/app/views/makes/new8.html.haml
+++ b/app/views/makes/new8.html.haml
@@ -3,9 +3,11 @@
     = link_to "#", onclick: "history.back()", class: "back-icon" do
       = icon("fa", "arrow-left")
     %p.lead
-      挫折しそうになった時の対策を考えましょう。
+      次に挫折しそうになった時の対策を考えましょう。
       %br
       どのような行動や考え方をすればその状況を克服できますか？
+      %br
+      「挫折しそうな状況になったら、対策を行う」という形で２つ目の自分ルールを作成してください。
     
     = form_for(:make, url: makes_new_9_path, method: :get) do |f|
       = f.hidden_field :title, value: @title

--- a/app/views/quits/new1.html.haml
+++ b/app/views/quits/new1.html.haml
@@ -1,8 +1,13 @@
-.container
-  %p
-    やめたい習慣はなんですか？
+.container.quits-new-wrapper
+  .jumbotron.mt-5.text-center
+    = link_to "#", onclick: "history.back()", class: "back-icon" do
+      = icon("fa", "arrow-left")
+    %p.lead
+      質問に答えながら２つの自分ルールを作成していきます。
+      %br
+      やめたい習慣はなんですか？
 
-  = form_for(:quit, url: quits_new_2_path, method: :get) do |f|
-    = f.text_area :title, required: true, maxlength: 255, class: "form-control", placeholder: "ついyoutubeを見てしまう"
+    = form_for(:quit, url: quits_new_2_path, method: :get) do |f|
+      = f.text_area :title, required: true, maxlength: 255, class: "form-control mt-5", placeholder: "ex）ついYouTubeを見てしまう"
 
-    = f.submit "次へ", class: "btn btn-info"
+      = f.submit "次へ", class: "btn btn-info mt-5"

--- a/app/views/quits/new1.html.haml
+++ b/app/views/quits/new1.html.haml
@@ -8,6 +8,6 @@
       やめたい習慣はなんですか？
 
     = form_for(:quit, url: quits_new_2_path, method: :get) do |f|
-      = f.text_area :title, required: true, maxlength: 255, class: "form-control mt-5", placeholder: "ex）ついYouTubeを見てしまう"
+      = f.text_field :title, required: true, maxlength: 255, class: "form-control mt-5", placeholder: "ex）ついYouTubeを見てしまう"
 
       = f.submit "次へ", class: "btn btn-info mt-5"

--- a/app/views/quits/new2.html.haml
+++ b/app/views/quits/new2.html.haml
@@ -1,12 +1,10 @@
-.container
-  %p
-    その習慣をついやってしまうのはどのような状況ですか？
-  %p
-    すぐに思いつかなかったら数日生活してみて、ついやってしまう状況を記録してみましょう
+.container.makes-new-wrapper
+  .jumbotron.mt-5.text-center
+    %p.lead
+      その習慣をついやってしまうのはどのような状況ですか？
+      %br
+      すぐに思いつかなかったら数日生活してみて、ついやってしまう状況を記録してみましょう
 
-  = form_for(:quit, url: quits_new_3_path, method: :get) do |f|
-    = f.hidden_field :title, value: @title
-    = f.text_area :situation, required: true, maxlength: 150, class: "form-control", placeholder: "自分の部屋で暇になったとき"
-
-    = link_to "戻る", "#", onclick: "history.back()", class: "btn btn-warning"
-    = f.submit "次へ", class: "btn btn-info"
+    = form_for(:quit, url: quits_new_3_path, method: :get) do |f|
+      = f.hidden_field :title, value: @title
+      = f.submit "次へ", class: "btn btn-info mt-5"

--- a/app/views/quits/new3.html.haml
+++ b/app/views/quits/new3.html.haml
@@ -1,14 +1,12 @@
-.container
-  %p
-    別の行動に置き換えて１つ目の自分ルールを作成します。
-  %p
-    「その状況になったら、〜を行う」という形で作ってみましょう。
-  %p
-    同時にはできない行動にしてください
+.container.quits-new-wrapper
+  .jumbotron.mt-5.text-center
+    = link_to "#", onclick: "history.back()", class: "back-icon" do
+      = icon("fa", "arrow-left")
+    %p.lead
+      ついやってしまう状況を入力してください
 
-  = form_for(:quit, url: quits_new_4_path, method: :get) do |f|
-    = f.hidden_field :title, value: @title
-    = f.text_area :rule1, required: true, maxlength: 255, class: "form-control", value: "#{@situation}になったら、〜をする"
+    = form_for(:quit, url: quits_new_4_path, method: :get) do |f|
+      = f.hidden_field :title, value: @title
+      = f.text_area :situation, required: true, maxlength: 150, class: "form-control mt-5", placeholder: "ex）自分の部屋で暇になったとき"
 
-    = link_to "戻る", "#", onclick: "history.back()", class: "btn btn-warning"
-    = f.submit "次へ", class: "btn btn-info"
+      = f.submit "次へ", class: "btn btn-info mt-5"

--- a/app/views/quits/new4.html.haml
+++ b/app/views/quits/new4.html.haml
@@ -1,15 +1,15 @@
-.container
-  %p
-    やめたい習慣を簡単にはできないようなルールを決めましょう
-  %p
-    コツは今より少なくとも２０秒以上余計に時間がかかるようにすることです。
-  %p
-    例）ついyoutubeをみてしまう→スマホからアプリを消して、見るときはパソコンで見る
+.container.makes-new-wrapper
+  .jumbotron.mt-5.text-center
+    = link_to "#", onclick: "history.back()", class: "back-icon" do
+      = icon("fa", "arrow-left")
+    %p.lead
+      やめたい習慣を代わりの行動におきかえて１つ目の自分ルールを作ります。
+      %br
+      「やってしまう状況になったら代わりの行動をする」という形で作ってみましょう。
+      %br
+      代わりの行動はやめたい習慣と同時にはできないものにしてください。
 
-  = form_for(:quit, url: quits_path) do |f|
-    = f.hidden_field :title, value: @title
-    = f.hidden_field :rule1, value: @rule1
-    = f.text_area :rule2, required: true, maxlength: 255, class: "form-control", placeholder: ""
-
-    = link_to "戻る", "#", onclick: "history.back()", class: "btn btn-warning"
-    = f.submit "次へ", class: "btn btn-info"
+    = form_for(:quit, url: quits_new_5_path, method: :get) do |f|
+      = f.hidden_field :title, value: @title
+      = f.hidden_field :situation, value: @situation
+      = f.submit "次へ", class: "btn btn-info mt-5"

--- a/app/views/quits/new5.html.haml
+++ b/app/views/quits/new5.html.haml
@@ -1,0 +1,14 @@
+.container.quits-new-wrapper
+  .jumbotron.mt-5.text-center
+    = link_to "#", onclick: "history.back()", class: "back-icon" do
+      = icon("fa", "arrow-left")
+    %p.lead
+      下のフォームを編集して１つ目の自分ルールを作成してください。
+      %br
+      ex）自分の部屋で暇になったら本を読む
+
+    = form_for(:quit, url: quits_new_6_path, method: :get) do |f|
+      = f.hidden_field :title, value: @title
+      = f.text_area :rule1, required: true, maxlength: 255, class: "form-control mt-5", value: "#{@situation}"
+
+      = f.submit "次へ", class: "btn btn-info mt-5"

--- a/app/views/quits/new6.html.haml
+++ b/app/views/quits/new6.html.haml
@@ -1,0 +1,13 @@
+.container.makes-new-wrapper
+  .jumbotron.mt-5.text-center
+    = link_to "#", onclick: "history.back()", class: "back-icon" do
+      = icon("fa", "arrow-left")
+    %p.lead
+      次にやめたい習慣を簡単にはできないようにするルールを決めましょう。
+      %br
+      コツは今より少なくとも２０秒以上余計に時間がかかるようにすることです。
+
+    = form_for(:quit, url: quits_new_7_path, method: :get) do |f|
+      = f.hidden_field :title, value: @title
+      = f.hidden_field :rule1, value: @rule1
+      = f.submit "次へ", class: "btn btn-info mt-5"

--- a/app/views/quits/new7.html.haml
+++ b/app/views/quits/new7.html.haml
@@ -1,0 +1,13 @@
+.container.quits-new-wrapper
+  .jumbotron.mt-5.text-center
+    = link_to "#", onclick: "history.back()", class: "back-icon" do
+      = icon("fa", "arrow-left")
+    %p.lead
+      ２つ目の自分ルールを作成してください。
+
+    = form_for(:quit, url: quits_path) do |f|
+      = f.hidden_field :title, value: @title
+      = f.hidden_field :rule1, value: @rule1
+      = f.text_area :rule2, required: true, maxlength: 255, class: "form-control mt-5", placeholder: "ex）スマホからアプリを消して、YouTubeはパソコンで見るようにする。"
+
+      = f.submit "完成！", class: "btn btn-info mt-5"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,5 +33,8 @@ Rails.application.routes.draw do
   get "/quits/new/2", to: "quits#new2"
   get "/quits/new/3", to: "quits#new3"
   get "/quits/new/4", to: "quits#new4"
+  get "/quits/new/5", to: "quits#new5"
+  get "/quits/new/6", to: "quits#new6"
+  get "/quits/new/7", to: "quits#new7"
   resources :quits, only: [:create]
 end


### PR DESCRIPTION
close #82 

## 概要
- #81 にならってquitのページのスタイリング
- 説明とフォームのテンプレートを分ける
- placeholderの文字色を薄くする

## テスト内容
- ブラウザ上でquitを作成できることを確認
- chromeの検証ツールで表示を確認

## 参考URL
- [placeholderにスタイルを当てる](http://www-creators.com/archives/2506)