### PR TITLE
safariでも戻るボタンが機能するようにする

### DIFF
--- a/app/views/makes/new1.html.haml
+++ b/app/views/makes/new1.html.haml
@@ -1,6 +1,6 @@
 .container.makes-new-wrapper
   .jumbotron.mt-5.text-center
-    = link_to "#", onclick: "history.back()", class: "back-icon" do
+    = link_to "javascript:void(0);", onclick: "history.back()", class: "back-icon" do
       = icon("fa", "arrow-left")
     %p.lead
       質問に答えながら２つの自分ルールを作成していきます。

--- a/app/views/makes/new2.html.haml
+++ b/app/views/makes/new2.html.haml
@@ -1,6 +1,6 @@
 .container.makes-new-wrapper
   .jumbotron.mt-5.text-center
-    = link_to "#", onclick: "history.back()", class: "back-icon" do
+    = link_to "javascript:void(0);", onclick: "history.back()", class: "back-icon" do
       = icon("fa", "arrow-left")
     %p.lead
       まずは１回の行動のノルマを決めます。

--- a/app/views/makes/new3.html.haml
+++ b/app/views/makes/new3.html.haml
@@ -1,6 +1,6 @@
 .container.makes-new-wrapper
   .jumbotron.mt-5.text-center
-    = link_to "#", onclick: "history.back()", class: "back-icon" do
+    = link_to "javascript:void(0);", onclick: "history.back()", class: "back-icon" do
       = icon("fa", "arrow-left")
 
     %p.lead

--- a/app/views/makes/new4.html.haml
+++ b/app/views/makes/new4.html.haml
@@ -1,6 +1,6 @@
 .container.makes-new-wrapper
   .jumbotron.mt-5.text-center
-    = link_to "#", onclick: "history.back()", class: "back-icon" do
+    = link_to "javascript:void(0);", onclick: "history.back()", class: "back-icon" do
       = icon("fa", "arrow-left")
     %p.lead
       いま決めたノルマをすでにある習慣と結びつけて１つ目の自分ルールを作ります。

--- a/app/views/makes/new5.html.haml
+++ b/app/views/makes/new5.html.haml
@@ -1,6 +1,6 @@
 .container.makes-new-wrapper
   .jumbotron.mt-5.text-center
-    = link_to "#", onclick: "history.back()", class: "back-icon" do
+    = link_to "javascript:void(0);", onclick: "history.back()", class: "back-icon" do
       = icon("fa", "arrow-left")
 
     %p.lead

--- a/app/views/makes/new6.html.haml
+++ b/app/views/makes/new6.html.haml
@@ -1,6 +1,6 @@
 .container.makes-new-wrapper
   .jumbotron.mt-5.text-center
-    = link_to "#", onclick: "history.back()", class: "back-icon" do
+    = link_to "javascript:void(0);", onclick: "history.back()", class: "back-icon" do
       = icon("fa", "arrow-left")
     %p.lead
       ２つ目の自分ルールを作成していきます。

--- a/app/views/makes/new7.html.haml
+++ b/app/views/makes/new7.html.haml
@@ -1,6 +1,6 @@
 .container.makes-new-wrapper
   .jumbotron.mt-5.text-center
-    = link_to "#", onclick: "history.back()", class: "back-icon" do
+    = link_to "javascript:void(0);", onclick: "history.back()", class: "back-icon" do
       = icon("fa", "arrow-left")
     %p.lead
       挫折しそうになる状況を入力してください。

--- a/app/views/makes/new8.html.haml
+++ b/app/views/makes/new8.html.haml
@@ -1,6 +1,6 @@
 .container.makes-new-wrapper
   .jumbotron.mt-5.text-center
-    = link_to "#", onclick: "history.back()", class: "back-icon" do
+    = link_to "javascript:void(0);", onclick: "history.back()", class: "back-icon" do
       = icon("fa", "arrow-left")
     %p.lead
       次に挫折しそうになった時の対策を考えましょう。

--- a/app/views/makes/new9.html.haml
+++ b/app/views/makes/new9.html.haml
@@ -1,6 +1,6 @@
 .container.makes-new-wrapper
   .jumbotron.mt-5.text-center
-    = link_to "#", onclick: "history.back()", class: "back-icon" do
+    = link_to "javascript:void(0);", onclick: "history.back()", class: "back-icon" do
       = icon("fa", "arrow-left")
     %p.lead
       下のフォームを編集して２つ目の自分ルールを作成してください。

--- a/app/views/quits/new1.html.haml
+++ b/app/views/quits/new1.html.haml
@@ -1,6 +1,6 @@
 .container.quits-new-wrapper
   .jumbotron.mt-5.text-center
-    = link_to "#", onclick: "history.back()", class: "back-icon" do
+    = link_to "javascript:void(0);", onclick: "history.back()", class: "back-icon" do
       = icon("fa", "arrow-left")
     %p.lead
       質問に答えながら２つの自分ルールを作成していきます。

--- a/app/views/quits/new2.html.haml
+++ b/app/views/quits/new2.html.haml
@@ -1,5 +1,7 @@
 .container.makes-new-wrapper
   .jumbotron.mt-5.text-center
+    = link_to "javascript:void(0);", onclick: "history.back()", class: "back-icon" do
+      = icon("fa", "arrow-left")
     %p.lead
       その習慣をついやってしまうのはどのような状況ですか？
       %br

--- a/app/views/quits/new3.html.haml
+++ b/app/views/quits/new3.html.haml
@@ -1,6 +1,6 @@
 .container.quits-new-wrapper
   .jumbotron.mt-5.text-center
-    = link_to "#", onclick: "history.back()", class: "back-icon" do
+    = link_to "javascript:void(0);", onclick: "history.back()", class: "back-icon" do
       = icon("fa", "arrow-left")
     %p.lead
       ついやってしまう状況を入力してください

--- a/app/views/quits/new4.html.haml
+++ b/app/views/quits/new4.html.haml
@@ -1,6 +1,6 @@
 .container.makes-new-wrapper
   .jumbotron.mt-5.text-center
-    = link_to "#", onclick: "history.back()", class: "back-icon" do
+    = link_to "javascript:void(0);", onclick: "history.back()", class: "back-icon" do
       = icon("fa", "arrow-left")
     %p.lead
       やめたい習慣を代わりの行動におきかえて１つ目の自分ルールを作ります。

--- a/app/views/quits/new5.html.haml
+++ b/app/views/quits/new5.html.haml
@@ -1,6 +1,6 @@
 .container.quits-new-wrapper
   .jumbotron.mt-5.text-center
-    = link_to "#", onclick: "history.back()", class: "back-icon" do
+    = link_to "javascript:void(0);", onclick: "history.back()", class: "back-icon" do
       = icon("fa", "arrow-left")
     %p.lead
       下のフォームを編集して１つ目の自分ルールを作成してください。

--- a/app/views/quits/new6.html.haml
+++ b/app/views/quits/new6.html.haml
@@ -1,6 +1,6 @@
 .container.makes-new-wrapper
   .jumbotron.mt-5.text-center
-    = link_to "#", onclick: "history.back()", class: "back-icon" do
+    = link_to "javascript:void(0);", onclick: "history.back()", class: "back-icon" do
       = icon("fa", "arrow-left")
     %p.lead
       次にやめたい習慣を簡単にはできないようにするルールを決めましょう。

--- a/app/views/quits/new7.html.haml
+++ b/app/views/quits/new7.html.haml
@@ -1,6 +1,6 @@
 .container.quits-new-wrapper
   .jumbotron.mt-5.text-center
-    = link_to "#", onclick: "history.back()", class: "back-icon" do
+    = link_to "javascript:void(0);", onclick: "history.back()", class: "back-icon" do
       = icon("fa", "arrow-left")
     %p.lead
       ２つ目の自分ルールを作成してください。


### PR DESCRIPTION
close #86 

## 概要
- 戻るボタンのリンク先を`#`から`javascript:void(0);`に変更

## テスト内容
- safariで戻るボタンが機能することを確認
- chromeでも戻るボタンが機能することを確認

## 参考URL
- [スタックオーバーフロー](https://ja.stackoverflow.com/questions/22012/history-back%E3%81%8C-%E6%88%90%E5%8A%9F%E3%81%97%E3%81%9F%E3%82%8A%E5%A4%B1%E6%95%97%E3%81%97%E3%81%9F%E3%82%8A%E3%81%99%E3%82%8B%E7%90%86%E7%94%B1%E3%81%AF)