### PR TITLE
習慣詳細ページの作成

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -279,6 +279,44 @@ ul {
   }
 }
 
+// make show, quit show
+.makes-show-wrapper, .quits-show-wrapper {
+  p {
+    margin: 0;
+  }
+
+  .jumbotron {
+    max-width: 600px;
+    background-color: #f7f7f7;
+    box-shadow: 0 2px 2px rgba(0, 0, 0, 0.3);
+    .title {
+      // background-color: #ccffcc;
+      border-radius: 3px 3px 0 0;
+    }
+    .section-title {
+      padding-top: 1rem;
+      opacity: .7;
+    }
+    .content {
+      padding: 1rem 0 1.5rem;
+      font-size: 1.6rem;
+      font-weight: 600;
+    }
+  }
+}
+
+.makes-show-wrapper {
+  .title {
+    background-color: #ccffcc;
+  }
+}
+
+.quits-show-wrapper {
+  .title {
+    background-color: #ffffd7;
+  }
+}
+
 // footer
 footer {
   height: 10vh;
@@ -288,7 +326,7 @@ footer {
 }
 
 // media query
-// 中デバイス用（タブレット）
+// 中デバイス用（小さめパソコン、大きめタブレット）
 @media (max-width: 991.98px) {
   .img-caption h1 {
     font-size: 350%;
@@ -309,7 +347,7 @@ footer {
   }
 }
 
-// 小デバイス用（スマホ）
+// 小デバイス用（小さめタブレット）
 @media (max-width: 767.98px) {
   .img-caption h1 {
     font-size: 250%;
@@ -403,7 +441,7 @@ footer {
   }
 }
 
-// 極小デバイス用（スマホ縦向き）
+// 極小デバイス用（スマホ）
 @media (max-width: 575.98px) {
   .habits-select-wrapper {
     .jumbotron {
@@ -417,6 +455,19 @@ footer {
     .lead {
       text-align: justify!important;
       letter-spacing: .05rem;
+    }
+  }
+
+  .makes-show-wrapper, .quits-show-wrapper {
+    .jumbotron {
+      text-align: justify!important;
+
+      .section-title {
+        font-size: .8rem;
+      }
+      .content {
+        font-size: 1.2rem;
+      }
     }
   }
 }

--- a/app/controllers/habits_controller.rb
+++ b/app/controllers/habits_controller.rb
@@ -3,4 +3,12 @@ class HabitsController < ApplicationController
 
   def select
   end
+
+  private
+
+    def check_correct_user
+      unless current_user.habits.find_by(id: params[:id])
+        redirect_to current_user
+      end
+    end
 end

--- a/app/controllers/makes_controller.rb
+++ b/app/controllers/makes_controller.rb
@@ -1,8 +1,9 @@
-class MakesController < ApplicationController
+class MakesController < HabitsController
   before_action :check_login
-  before_action :forbid_direct_access, except: [:new1]
+  before_action :forbid_direct_access, except: [:new1, :show]
   before_action :set_title, only: [:new2, :new3, :new4, :new5, :new6, :new7, :new8, :new9]
   before_action :set_rule1, only: [:new6, :new7, :new8, :new9]
+  before_action :check_correct_user, only: [:show]
 
   def new1
   end
@@ -39,11 +40,15 @@ class MakesController < ApplicationController
     make = current_user.makes.build(make_params)
     if make.save
       flash[:success] = "自分ルールを作成しました！"
-      redirect_to current_user
+      redirect_to make
     else
       flash[:warning] = "データの保存に失敗しました。お手数ですがもう一度やり直してください。"
       redirect_to makes_new_1_url
     end
+  end
+
+  def show
+    @make = current_user.makes.find(params[:id])
   end
 
   private

--- a/app/controllers/quits_controller.rb
+++ b/app/controllers/quits_controller.rb
@@ -1,8 +1,9 @@
-class QuitsController < ApplicationController
+class QuitsController < HabitsController
   before_action :check_login
-  before_action :forbid_direct_access, except: [:new1]
+  before_action :forbid_direct_access, except: [:new1, :show]
   before_action :set_title, only: [:new2, :new3, :new4, :new5, :new6, :new7]
   before_action :set_rule1, only: [:new6, :new7]
+  before_action :check_correct_user, only: [:show]
 
   def new1
   end
@@ -31,11 +32,15 @@ class QuitsController < ApplicationController
     quit = current_user.quits.build(quit_params)
     if quit.save
       flash[:success] = "自分ルールを作成しました！"
-      redirect_to current_user
+      redirect_to quit
     else
       flash[:warning] = "データの保存に失敗しました。お手数ですがもう一度やり直してください。"
       redirect_to quits_new_1_url
     end
+  end
+
+  def show
+    @quit = current_user.quits.find(params[:id])
   end
 
   private

--- a/app/views/makes/new7.html.haml
+++ b/app/views/makes/new7.html.haml
@@ -8,6 +8,6 @@
     = form_for(:make, url: makes_new_8_path, method: :get) do |f|
       = f.hidden_field :title, value: @title
       = f.hidden_field :rule1, value: @rule1
-      = f.text_area :situation, required: true, maxlength: 150, class: "form-control mt-5", placeholder: "ex）めんどくさくなってしまう"
+      = f.text_field :situation, required: true, maxlength: 150, class: "form-control mt-5", placeholder: "ex）めんどくさくなってしまう"
 
       = f.submit "次へ", class: "btn btn-info mt-5"

--- a/app/views/makes/show.html.haml
+++ b/app/views/makes/show.html.haml
@@ -1,0 +1,15 @@
+%h1
+  習慣詳細(Make)
+%ul
+  %li
+    = @make.title
+  %li
+    = @make.rule1
+  %li
+    = @make.rule2
+  %li
+    = @make.user.id
+  %li
+    = @make.user.email
+  %li
+    = @make.user.name

--- a/app/views/makes/show.html.haml
+++ b/app/views/makes/show.html.haml
@@ -1,15 +1,18 @@
-%h1
-  習慣詳細(Make)
-%ul
-  %li
-    = @make.title
-  %li
-    = @make.rule1
-  %li
-    = @make.rule2
-  %li
-    = @make.user.id
-  %li
-    = @make.user.email
-  %li
-    = @make.user.name
+.container.makes-show-wrapper
+  .jumbotron.mt-5.mx-auto.p-0.text-center
+    %section.title.border-bottom.px-3
+      %p.section-title 身につけたい習慣
+      %p.content
+        = @make.title
+    %section.rule1.border-bottom.px-3
+      %p.section-title ルール①
+      %p.content
+        = @make.rule1
+    %section.rule2.border-bottom.px-3
+      %p.section-title ルール②
+      %p.content
+        = @make.rule2
+    %section.date.px-3
+      %p.section-title 作成日
+      %p.content
+        = @make.created_at.strftime('%Y/%m/%d')

--- a/app/views/quits/new3.html.haml
+++ b/app/views/quits/new3.html.haml
@@ -7,6 +7,6 @@
 
     = form_for(:quit, url: quits_new_4_path, method: :get) do |f|
       = f.hidden_field :title, value: @title
-      = f.text_area :situation, required: true, maxlength: 150, class: "form-control mt-5", placeholder: "ex）自分の部屋で暇になったとき"
+      = f.text_field :situation, required: true, maxlength: 150, class: "form-control mt-5", placeholder: "ex）自分の部屋で暇になったとき"
 
       = f.submit "次へ", class: "btn btn-info mt-5"

--- a/app/views/quits/show.html.haml
+++ b/app/views/quits/show.html.haml
@@ -1,0 +1,15 @@
+%h1
+  習慣詳細(Quit)
+%ul
+  %li
+    = @quit.title
+  %li
+    = @quit.rule1
+  %li
+    = @quit.rule2
+  %li
+    = @quit.user.id
+  %li
+    = @quit.user.email
+  %li
+    = @quit.user.name

--- a/app/views/quits/show.html.haml
+++ b/app/views/quits/show.html.haml
@@ -1,15 +1,18 @@
-%h1
-  習慣詳細(Quit)
-%ul
-  %li
-    = @quit.title
-  %li
-    = @quit.rule1
-  %li
-    = @quit.rule2
-  %li
-    = @quit.user.id
-  %li
-    = @quit.user.email
-  %li
-    = @quit.user.name
+.container.quits-show-wrapper
+  .jumbotron.mt-5.mx-auto.p-0.text-center
+    %section.title.border-bottom.px-3
+      %p.section-title やめたい習慣
+      %p.content
+        = @quit.title
+    %section.rule1.border-bottom.px-3
+      %p.section-title ルール①
+      %p.content
+        = @quit.rule1
+    %section.rule2.border-bottom.px-3
+      %p.section-title ルール②
+      %p.content
+        = @quit.rule2
+    %section.date.px-3
+      %p.section-title 作成日
+      %p.content
+        = @quit.created_at.strftime('%Y/%m/%d')

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -19,3 +19,13 @@
 
 - if @user == current_user && @user.admin?
   = link_to "ユーザー管理画面", admin_users_path, class: "btn btn-success"
+
+%br
+make
+- @user.makes.each do |make|
+  = link_to make.id, make
+
+%br
+quit
+- @user.quits.each do |quit|
+  = link_to quit.id, quit

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,7 @@ module MakeHabits
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
+    config.time_zone = "Asia/Tokyo"
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
 
   get "/habits/select", to: "habits#select"
 
+  resources :makes, only: [:create, :show]
   get "/makes/new/1", to: "makes#new1"
   get "/makes/new/2", to: "makes#new2"
   get "/makes/new/3", to: "makes#new3"
@@ -27,8 +28,8 @@ Rails.application.routes.draw do
   get "/makes/new/7", to: "makes#new7"
   get "/makes/new/8", to: "makes#new8"
   get "/makes/new/9", to: "makes#new9"
-  resources :makes, only: [:create]
 
+  resources :quits, only: [:create, :show]
   get "/quits/new/1", to: "quits#new1"
   get "/quits/new/2", to: "quits#new2"
   get "/quits/new/3", to: "quits#new3"
@@ -36,5 +37,4 @@ Rails.application.routes.draw do
   get "/quits/new/5", to: "quits#new5"
   get "/quits/new/6", to: "quits#new6"
   get "/quits/new/7", to: "quits#new7"
-  resources :quits, only: [:create]
 end


### PR DESCRIPTION
close #85 

## 概要
- `makes#show`と`quits#show`の作成
- 習慣詳細は作ったユーザーしか閲覧できない
  - `check_correct_user`メソッドをhabitsコントローラーに定義
  - makesコントローラーとquitsコントローラーをhabitsコントローラーと継承関係にする
- ルール作成後は習慣詳細ページにリダイレクト
- アプリのデフォルトのタイムゾーンを日本に設定

## テスト内容
- 他のユーザーが作成した習慣詳細ページへアクセスできないことを確認
- ルール作成後に詳細ページにリダイレクトされることを確認
- 詳細ページに表示される日時が日本時間であることを確認
- chromeの検証ツールで表記を確認

## 参考URL
- [TimeZone設定](https://qiita.com/neuwell/items/ea661b8b580d4e3a7be3)
- [created_atの表記](https://qiita.com/salvage0707/items/5f7888c6b5725a0aa6f3)