### PR TITLE
URLのidをハッシュ化する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,8 @@ gem "omniauth-twitter"
 # pagination
 gem "kaminari"
 
+gem "hashid-rails", "~> 1.0"
+
 group :development, :test do
   gem "onkcop", require: false
   gem "pry-byebug"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,6 +109,10 @@ GEM
       haml (>= 4.0.6, < 6.0)
       html2haml (>= 1.0.1)
       railties (>= 4.0.1)
+    hashid-rails (1.2.2)
+      activerecord (>= 4.0)
+      hashids (~> 1.0)
+    hashids (1.0.5)
     hashie (3.6.0)
     html2haml (2.2.0)
       erubis (~> 2.7.0)
@@ -312,6 +316,7 @@ DEPENDENCIES
   erb2haml
   font-awesome-sass (~> 5.6.1)
   haml-rails
+  hashid-rails (~> 1.0)
   jbuilder (~> 2.5)
   jquery-rails
   kaminari

--- a/app/controllers/habits_controller.rb
+++ b/app/controllers/habits_controller.rb
@@ -14,7 +14,7 @@ class HabitsController < ApplicationController
   private
 
     def check_correct_user
-      unless current_user.habits.find_by(id: params[:id])
+      unless current_user.habits.find_by_hashid(params[:id]) # rubocop:disable Rails/DynamicFindBy
         redirect_to current_user
       end
     end

--- a/app/models/habit.rb
+++ b/app/models/habit.rb
@@ -1,4 +1,5 @@
 class Habit < ApplicationRecord
+  include Hashid::Rails
   validates :title, presence: true, length: { maximum: 255 }
   validates :rule1, presence: true, length: { maximum: 255 }
   validates :rule2, presence: true, length: { maximum: 255 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+  include Hashid::Rails
   attr_accessor :remember_token, :activation_token, :reset_token
   before_save :downcase_email
   before_create :create_activation_digest


### PR DESCRIPTION
close #96 

## 概要
- [hashid-rails](https://github.com/jcypret/hashid-rails)を使ってURLのidをハッシュ化して表示する
  - 基本的には使うモデルに`include Hashid::Rails`を記述するだけでよしなにやってくれる
  - ただ`Model.find_by(id: params[:id])`を使う場合は`Model.find_by_hashid(params[:id])`にする必要があるので注意が必要
    - `params[:id]`がハッシュ化されるため
    - `Model.find(params[:id])`はそのまま使えるから大丈夫

## テスト内容
- UserとHabitについてURLのidがハッシュ化されて表示されていることを確認
- 他の操作に影響を及ぼしていないことを確認

## 参考URL
- [hashid-rails](https://github.com/jcypret/hashid-rails)