### PR TITLE
習慣詳細に進捗スライダーを実装する

### DIFF
--- a/app/assets/javascripts/habits.coffee
+++ b/app/assets/javascripts/habits.coffee
@@ -1,3 +1,0 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/habits.js
+++ b/app/assets/javascripts/habits.js
@@ -1,0 +1,14 @@
+document.addEventListener('turbolinks:load', function() {
+  const element = document.getElementsByClassName('progressRange');
+  const setRangeValue = (element, target) => {
+    return function(e) {
+      target.innerHTML = `${element.value}%`;
+    };
+  };
+  for (let i = 0; i < element.length; i++) {
+    // form_for使うと自動で３つのinputタグが生成されるから、自分で追加したものは４つ目以降になる
+    bar = element[i].getElementsByTagName('input')[3];
+    target = element[i].getElementsByTagName('span')[0];
+    bar.addEventListener('input', setRangeValue(bar, target));
+  }
+});

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -290,7 +290,6 @@ ul {
     background-color: #f7f7f7;
     box-shadow: 0 2px 2px rgba(0, 0, 0, 0.3);
     .title {
-      // background-color: #ccffcc;
       border-radius: 3px 3px 0 0;
     }
     .section-title {
@@ -301,6 +300,28 @@ ul {
       padding: 1rem 0 1.5rem;
       font-size: 1.6rem;
       font-weight: 600;
+    }
+    .progressRange {
+      padding: 1rem 0 1.5rem;
+      input[type="range"] {
+        width: 65%;
+        cursor: pointer;
+      }
+      span {
+        position: absolute;
+        margin-left: 8px;
+        -webkit-transform: translateY(-2px);
+        transform: translateY(-2px);
+      }
+    }
+  }
+  .delete-rule {
+    color: #999999;
+    display: inline-block;
+    margin: 1rem 0 3rem;
+    &:hover {
+      text-decoration: none;
+      color: #000000;
     }
   }
 }
@@ -467,6 +488,11 @@ footer {
       }
       .content {
         font-size: 1.2rem;
+      }
+      .progressRange {
+        input[type="range"] {
+          width: 85%;
+        }
       }
     }
   }

--- a/app/controllers/makes_controller.rb
+++ b/app/controllers/makes_controller.rb
@@ -47,6 +47,12 @@ class MakesController < HabitsController
     end
   end
 
+  def update
+    make = current_user.makes.find(params[:id])
+    make.update!(make_params)
+    head :no_content
+  end
+
   def show
     @make = current_user.makes.find(params[:id])
   end
@@ -54,7 +60,7 @@ class MakesController < HabitsController
   private
 
     def make_params
-      params.require(:make).permit(:title, :rule1, :rule2)
+      params.require(:make).permit(:title, :rule1, :rule2, :progress)
     end
 
     def forbid_direct_access

--- a/app/controllers/quits_controller.rb
+++ b/app/controllers/quits_controller.rb
@@ -39,6 +39,12 @@ class QuitsController < HabitsController
     end
   end
 
+  def update
+    quit = current_user.quits.find(params[:id])
+    quit.update!(quit_params)
+    head :no_content
+  end
+
   def show
     @quit = current_user.quits.find(params[:id])
   end
@@ -46,7 +52,7 @@ class QuitsController < HabitsController
   private
 
     def quit_params
-      params.require(:quit).permit(:title, :rule1, :rule2)
+      params.require(:quit).permit(:title, :rule1, :rule2, :progress)
     end
 
     def forbid_direct_access

--- a/app/views/makes/show.html.haml
+++ b/app/views/makes/show.html.haml
@@ -12,9 +12,16 @@
       %p.section-title ルール②
       %p.content
         = @make.rule2
-    %section.date.px-3
+    %section.date.border-bottom.px-3
       %p.section-title 作成日
       %p.content
         = @make.created_at.strftime('%Y/%m/%d')
+    %section
+      %p.section-title 進捗
+      .progressRange
+        = form_for(@make, remote: true) do |f|
+          = f.range_field :progress, min: 0, max: 100, step: 1, value: @make.progress, onchange: 'Rails.fire(this.form, "submit")'
+          %span
+            = "#{@make.progress}%"
 
   = link_to "削除", habit_path(@make), method: :delete, class: "btn btn-secondary text-center", data: { confirm: "本当に削除しますか？" }

--- a/app/views/makes/show.html.haml
+++ b/app/views/makes/show.html.haml
@@ -16,7 +16,7 @@
       %p.section-title 作成日
       %p.content
         = @make.created_at.strftime('%Y/%m/%d')
-    %section
+    %section.px-3
       %p.section-title 進捗
       .progressRange
         = form_for(@make, remote: true) do |f|
@@ -24,4 +24,4 @@
           %span
             = "#{@make.progress}%"
 
-  = link_to "削除", habit_path(@make), method: :delete, class: "btn btn-secondary text-center", data: { confirm: "本当に削除しますか？" }
+  = link_to "削除する", habit_path(@make), method: :delete, class: "text-center delete-rule", data: { confirm: "このルールを削除しますか？" }

--- a/app/views/quits/show.html.haml
+++ b/app/views/quits/show.html.haml
@@ -16,5 +16,12 @@
       %p.section-title 作成日
       %p.content
         = @quit.created_at.strftime('%Y/%m/%d')
+    %section
+      %p.section-title 進捗
+      .progressRange
+        = form_for(@quit, remote: true) do |f|
+          = f.range_field :progress, min: 0, max: 100, step: 1, value: @quit.progress, onchange: 'Rails.fire(this.form, "submit")'
+          %span
+            = "#{@quit.progress}%"
 
   = link_to "削除", habit_path(@quit), method: :delete, class: "btn btn-secondary d-inline-block", data: { confirm: "本当に削除しますか？" }

--- a/app/views/quits/show.html.haml
+++ b/app/views/quits/show.html.haml
@@ -12,11 +12,11 @@
       %p.section-title ルール②
       %p.content
         = @quit.rule2
-    %section.date.px-3
+    %section.date.border-bottom.px-3
       %p.section-title 作成日
       %p.content
         = @quit.created_at.strftime('%Y/%m/%d')
-    %section
+    %section.px-3
       %p.section-title 進捗
       .progressRange
         = form_for(@quit, remote: true) do |f|
@@ -24,4 +24,4 @@
           %span
             = "#{@quit.progress}%"
 
-  = link_to "削除", habit_path(@quit), method: :delete, class: "btn btn-secondary d-inline-block", data: { confirm: "本当に削除しますか？" }
+  = link_to "削除する", habit_path(@quit), method: :delete, class: "text-center delete-rule", data: { confirm: "このルールを削除しますか？" }

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,7 +11,7 @@ module MakeHabits
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
     config.time_zone = "Asia/Tokyo"
-
+    config.action_view.embed_authenticity_token_in_remote_forms = true
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -23,7 +23,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = Uglifier.new(harmony: true)
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ Rails.application.routes.draw do
   resources :habits, only: [:destroy]
   get "/habits/select", to: "habits#select"
 
-  resources :makes, only: [:create, :show]
+  resources :makes, only: [:create, :show, :update]
   get "/makes/new/1", to: "makes#new1"
   get "/makes/new/2", to: "makes#new2"
   get "/makes/new/3", to: "makes#new3"
@@ -30,7 +30,7 @@ Rails.application.routes.draw do
   get "/makes/new/8", to: "makes#new8"
   get "/makes/new/9", to: "makes#new9"
 
-  resources :quits, only: [:create, :show]
+  resources :quits, only: [:create, :show, :update]
   get "/quits/new/1", to: "quits#new1"
   get "/quits/new/2", to: "quits#new2"
   get "/quits/new/3", to: "quits#new3"

--- a/db/migrate/20190316083639_add_progress_to_habits.rb
+++ b/db/migrate/20190316083639_add_progress_to_habits.rb
@@ -1,0 +1,5 @@
+class AddProgressToHabits < ActiveRecord::Migration[5.2]
+  def change
+    add_column :habits, :progress, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_07_171959) do
+ActiveRecord::Schema.define(version: 2019_03_16_083639) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,6 +23,7 @@ ActiveRecord::Schema.define(version: 2019_03_07_171959) do
     t.datetime "updated_at", null: false
     t.string "rule1", null: false
     t.string "rule2", null: false
+    t.integer "progress", default: 0, null: false
     t.index ["user_id"], name: "index_habits_on_user_id"
   end
 


### PR DESCRIPTION
close #90 

## 概要
- デフォルトのタイムゾーンを東京に設定
- habitsテーブルにprogressカラムを追加
- 詳細ページにスライダーを追加
  - `<input type="range">`でスライダー作れる
- progressの値を非同期処理で保存
  - form_forに`remote: true`を指定することでajaxリクエストにできる
  - onchangeでJavaScriptのsubmitを使うとajaxにならないので`Rails.fire`を使う必要がある
- 本番環境でES6を使うためにuglifierの設定を変える

## テスト内容
- スライダーの数値がDBに保存されることを確認
- トピックブランチをデプロイして表示を確認（ipadとiPhoneの実機でも確認）

## 補足
- `<input type="range">`の見た目はブラウザによって割と違うらしいから、とりあえずデフォルトのデザインのまま
- chromeの検証でタブレットやスマホ表示にするとなぜかスライダーが表示されなかったけど、実機では表示されたから大丈夫なはず

## 参考URL
- ajax関連
  - 現場Rails
  - [onchangeでajaxリクエスト①](https://stackoverflow.com/questions/6959481/rails-trying-to-submit-a-form-onchange-of-dropdown)
  - [onchangeでajaxリクエスト②](https://blog.rista.jp/entry/2017/09/04/100006)
- [スライダーの値をリアルタイムで表示する](https://beiznotes.org/input-range-show-value/)
- [本番環境でES6を使う（uglifierの設定）](https://qiita.com/Thort/items/18c44604aba65303c221)
