### PR TITLE
ルールを画像保存できるようにする

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -16,4 +16,6 @@
 //= require rails-ujs
 //= require activestorage
 //= require turbolinks
+//= require html2canvas/dist/html2canvas.js
+//= require html2canvas/dist/html2canvas.min.js
 //= require_tree .

--- a/app/assets/javascripts/habits.js
+++ b/app/assets/javascripts/habits.js
@@ -1,4 +1,6 @@
 document.addEventListener('turbolinks:load', function() {
+
+  // スライダーの現在値を取得する
   const element = document.getElementsByClassName('progressRange');
   const setRangeValue = (element, target) => {
     return function(e) {
@@ -10,5 +12,27 @@ document.addEventListener('turbolinks:load', function() {
     bar = element[i].getElementsByTagName('input')[3];
     target = element[i].getElementsByTagName('span')[0];
     bar.addEventListener('input', setRangeValue(bar, target));
-  }
+  };
+
+  // makeの画像保存
+  const ruleForMake = document.getElementById('make-rule');
+  if (ruleForMake !== null) {
+    html2canvas(ruleForMake).then(function(canvas) {
+    const canvasImage = canvas.toDataURL('image/png');
+    document.getElementById('make-download').setAttribute('href', canvasImage);
+    // スライダーがcanvasだとうまく描画されないため、画像には進捗は含めない
+    document.getElementById('make-progress').classList.remove('d-none');
+    });
+  };
+
+  // quitの画像保存
+  const ruleForQuit = document.getElementById('quit-rule');
+  if (ruleForQuit !== null) {
+    html2canvas(ruleForQuit).then(function(canvas) {
+    const canvasImage = canvas.toDataURL('image/png');
+    document.getElementById('quit-download').setAttribute('href', canvasImage);
+    // スライダーがcanvasだとうまく描画されないため、画像には進捗は含めない
+    document.getElementById('quit-progress').classList.remove('d-none');
+    });
+  };
 });

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -350,14 +350,8 @@ ul {
       }
     }
   }
-  .delete-rule {
-    color: #999999;
-    display: inline-block;
-    margin: 1rem 0 3rem;
-    &:hover {
-      text-decoration: none;
-      color: #000000;
-    }
+  .btn {
+    font-size: .9rem;
   }
 }
 
@@ -544,6 +538,9 @@ footer {
           width: 85%;
         }
       }
+    }
+    .btn {
+      font-size: .8rem;
     }
   }
 }

--- a/app/views/makes/show.html.haml
+++ b/app/views/makes/show.html.haml
@@ -1,5 +1,5 @@
 .container.makes-show-wrapper.text-center
-  .jumbotron.mt-5.mx-auto.p-0
+  .jumbotron.mt-5.mx-auto.p-0#make-rule
     %section.title.border-bottom.px-3
       %p.section-title 身につけたい習慣
       %p.content
@@ -16,12 +16,13 @@
       %p.section-title 作成日
       %p.content
         = @make.created_at.strftime('%Y/%m/%d')
-    %section.px-3
+    %section.px-3.d-none#make-progress
       %p.section-title 進捗
       .progressRange
         = form_for(@make, remote: true) do |f|
           = f.range_field :progress, min: 0, max: 100, step: 1, value: @make.progress, onchange: 'Rails.fire(this.form, "submit")'
           %span
             = "#{@make.progress}%"
-
-  = link_to "削除する", habit_path(@make), method: :delete, class: "text-center delete-rule", data: { confirm: "このルールを削除しますか？" }
+  .row
+    = link_to "画像をダウンロードする", "#", download: "myrule_#{@make.id}", id: "make-download", class: "btn btn-success col-6 offset-3 col-md-4 offset-md-4 mt-4 mb-2"
+    = link_to "ルールを削除する", habit_path(@make), method: :delete, class: "btn btn-secondary col-6 offset-3 col-md-4 offset-md-4 my-5", data: { confirm: "このルールを削除しますか？" }

--- a/app/views/quits/show.html.haml
+++ b/app/views/quits/show.html.haml
@@ -1,5 +1,5 @@
 .container.quits-show-wrapper.text-center
-  .jumbotron.mt-5.mx-auto.p-0
+  .jumbotron.mt-5.mx-auto.p-0#quit-rule
     %section.title.border-bottom.px-3
       %p.section-title やめたい習慣
       %p.content
@@ -16,12 +16,13 @@
       %p.section-title 作成日
       %p.content
         = @quit.created_at.strftime('%Y/%m/%d')
-    %section.px-3
+    %section.px-3.d-none#quit-progress
       %p.section-title 進捗
       .progressRange
         = form_for(@quit, remote: true) do |f|
           = f.range_field :progress, min: 0, max: 100, step: 1, value: @quit.progress, onchange: 'Rails.fire(this.form, "submit")'
           %span
             = "#{@quit.progress}%"
-
-  = link_to "削除する", habit_path(@quit), method: :delete, class: "text-center delete-rule", data: { confirm: "このルールを削除しますか？" }
+  .row
+    = link_to "画像をダウンロードする", "#", download: "myrule_#{@quit.id}", id: "quit-download", class: "btn btn-success col-6 offset-3 col-md-4 offset-md-4 mt-4 mb-2"
+    = link_to "ルールを削除する", habit_path(@quit), method: :delete, class: "btn btn-secondary col-6 offset-3 col-md-4 offset-md-4 my-5", data: { confirm: "このルールを削除しますか？" }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,7 @@
 {
   "name": "make-habits",
   "private": true,
-  "dependencies": {}
+  "dependencies": {
+    "html2canvas": "^1.0.0-alpha.12"
+  }
 }


### PR DESCRIPTION
close #101 

## 概要
-  [html2canvas](https://html2canvas.hertzen.com/)を利用して画像をキャプチャして保存する機能を作成

## テスト内容
- ルール詳細のキャプチャ画像を保存できることを確認
- トピックブランチをデプロイして、スマホでも機能することを確認

## 補足
- スライダーがキャプチャ画像ではうまく描画されなかったため、画像にはスライダーを含めなかった
- yarnを利用して`html2canvas`をインストールしたため、herokuのビルドパックの設定を変更する必要があった

## 参考URL
- [html2canvas](https://html2canvas.hertzen.com/)
- [html2canvasを利用したダウンロード機能](https://qiita.com/tonishi/items/91ad735c9fac6e77fd22)
- [herokuのbuildpacksについて](https://qiita.com/patorash/items/78998aa18548cd7feb1a)