### PR TITLE
管理ユーザーの管理ページへのリダイレクトとユーザー編集フォームの修正

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -10,7 +10,7 @@ class SessionsController < ApplicationController
     if user && user.authenticate(params[:session][:password])
       log_in user
       (params[:session][:remember_me] == "1") ? remember(user) : forget(user)
-      redirect_back_or user
+      user.admin? ? redirect_to(admin_users_path) : redirect_back_or(user)
       flash[:info] = "ログインしました"
     else
       flash.now[:danger] = "メールアドレスかパスワードが間違っています"

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -15,7 +15,7 @@
 
           = f.submit "プロフィールを更新する", class: "btn btn-info btn-block btn-signup mt-4"
       #password-edit.tab-pane.fade.col-12
-        = form_for(@user, url: update_password_path(params[:id])) do |f|
+        = form_for(@user, url: update_password_path(params[:id]), html: {id: "user_edit_2"}) do |f|
           = render "shared/error_messages", object: f.object
           = f.password_field :current_password, required: true, class: "form-control placeholder mt-5 mb-4", placeholder: "現在のパスワード"
 


### PR DESCRIPTION
issue #92 

## 概要
- 管理ユーザーはログイン直後に管理ページにリダイレクトさせる
- ユーザー編集フォームのidが重複しないように修正

## テスト内容
- 管理ユーザーがログインすると管理ページにリダイレクトされることを確認
  - 非管理ユーザーは今まで通りの挙動になっていることを確認
- ユーザー編集を行えることを確認