### PR TITLE
ヘッダーの項目変更とツイッターユーザー向けのプロフィール編集

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -50,14 +50,30 @@ ul {
 }
 
 // header
-.navbar {
-  padding: .8rem;
-}
-.navbar-nav li {
-  padding-right: 20px;
-}
-.nav-link {
-  font-size: 1.1em !important;
+header {
+  .navbar {
+    padding: .8rem;
+  }
+  .navbar-nav li {
+    padding-right: 20px;
+  }
+  .nav-link {
+    font-size: 1.1em;
+  }
+  .user-img {
+    border-radius: 50%;
+    height: 30px;
+    margin-right: 1px;
+    -webkit-transform: translateY(-2px);
+    transform: translateY(-2px);
+  }
+  .dropdown-item {
+    padding: 1rem 1.5rem;
+    &:active {
+      background-color: #f8f8f8;
+      color: #000;
+    }
+  }
 }
 
 // error message
@@ -79,6 +95,7 @@ ul {
   position: absolute;
   top: 50%;
   left: 5%;
+  -webkit-transform: translateY(-50%);
   transform: translateY(-50%);
   color: #fff;
 }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,7 @@
 class UsersController < ApplicationController # rubocop:disable Metrics/ClassLength
   before_action :check_login, only: [:index, :show, :edit, :update_profile, :update_password, :delete, :destroy]
   before_action :forbid_login_user, only: [:new, :create]
-  before_action :forbid_twitter_login_user, only: [:edit, :update_profile, :update_password]
+  before_action :forbid_twitter_login_user, only: [:update_password]
   before_action :check_correct_user, only: [:show, :edit, :update_profile, :update_password, :delete]
   before_action :check_admin, only: [:index]
   before_action :check_destroy, only: [:destroy]

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -11,9 +11,16 @@
             %li.nav-item
               = link_to "自分ルールを作成する", habits_select_path, class: "nav-link"
             %li.nav-item
-              = link_to "マイページ", current_user, class: "nav-link"
-            %li.nav-item
-              = link_to "ログアウト", logout_path, method: "delete", class: "nav-link"
+              = link_to "自分ルール一覧", current_user, class: "nav-link"
+            %li.nav-item.dropdown
+              %a.nav-link.dropdown-toggle#navbarDropdown{"data-toggle" => "dropdown", "role" => "button", "aria-haspopup" => "true", "aria-expanded" => "false"}
+                - if current_user.provider == "twitter"
+                  %img.user-img{src: current_user.image_url}
+                %span.user-name
+                  = current_user.name
+              .dropdown-menu.dropdown-menu-right{"aria-haspopup" => "true"}
+                = link_to "プロフィール編集", edit_user_path(current_user), class: "dropdown-item"
+                = link_to "ログアウト", logout_path, method: "delete", class: "dropdown-item"
           - else
             %li.nav-item
               = link_to "新規登録", signup_path, class: "nav-link"

--- a/app/views/users/_edit_form.html.haml
+++ b/app/views/users/_edit_form.html.haml
@@ -1,0 +1,24 @@
+%ul.nav.nav-tabs.nav-justified.text-center
+  %li.active.col-6
+    .show.active.select-edit-tab.pb-2{ "data-target" => "#profile-edit", "data-toggle" => "tab"} プロフィール
+  %li.col-6
+    .select-edit-tab.pb-2{ "data-target" => "#password-edit", "data-toggle" => "tab"} パスワード
+.tab-content.tabs-profile-edit.col-12
+  #profile-edit.tab-pane.fade.active.show.in
+    = form_for(user, url: update_profile_path(params[:id])) do |f|
+      = render "shared/error_messages", object: f.object
+      = f.text_field :name, required: true, maxlength: 50, class: "form-control placeholder mt-5 mb-4", placeholder: "ユーザー名"
+
+      = f.email_field :email, required: true, maxlength: 255, class: "form-control placeholder mb-4", placeholder: "メールアドレス"
+
+      = f.submit "プロフィールを更新する", class: "btn btn-info btn-block btn-signup mt-4"
+  #password-edit.tab-pane.fade.col-12
+    = form_for(user, url: update_password_path(params[:id]), html: {id: "user_edit_2"}) do |f|
+      = render "shared/error_messages", object: f.object
+      = f.password_field :current_password, required: true, class: "form-control placeholder mt-5 mb-4", placeholder: "現在のパスワード"
+
+      = f.password_field :password, required: true, maxlength: 50, class: "form-control placeholder mb-4", placeholder: "新しいパスワード（６文字以上）"
+
+      = f.password_field :password_confirmation, required: true, maxlength: 50, class: "form-control placeholder", placeholder: "新しいパスワード（確認）"
+
+      = f.submit "パスワードを更新する", class: "btn btn-info btn-block btn-signup mt-4"

--- a/app/views/users/_edit_form_for_twitter.html.haml
+++ b/app/views/users/_edit_form_for_twitter.html.haml
@@ -1,0 +1,9 @@
+%p.text-center
+  プロフィール編集
+= form_for(user, url: update_profile_path(params[:id])) do |f|
+  = render "shared/error_messages", object: f.object
+  = f.text_field :name, required: true, maxlength: 50, class: "form-control placeholder mt-3 mb-4", placeholder: "新しいユーザー名", value: ""
+  
+  = hidden_field_tag :email, user.email
+
+  = f.submit "プロフィールを更新する", class: "btn btn-info btn-block btn-signup mt-4"

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -1,27 +1,7 @@
 .container.user-edit-wrapper
   .card.card-container
-    %ul.nav.nav-tabs.nav-justified.text-center
-      %li.active.col-6
-        .show.active.select-edit-tab.pb-2{ "data-target" => "#profile-edit", "data-toggle" => "tab"} プロフィール
-      %li.col-6
-        .select-edit-tab.pb-2{ "data-target" => "#password-edit", "data-toggle" => "tab"} パスワード
-    .tab-content.tabs-profile-edit.col-12
-      #profile-edit.tab-pane.fade.active.show.in
-        = form_for(@user, url: update_profile_path(params[:id])) do |f|
-          = render "shared/error_messages", object: f.object
-          = f.text_field :name, required: true, maxlength: 50, class: "form-control placeholder mt-5 mb-4", placeholder: "ユーザー名"
-
-          = f.email_field :email, required: true, maxlength: 255, class: "form-control placeholder mb-4", placeholder: "メールアドレス"
-
-          = f.submit "プロフィールを更新する", class: "btn btn-info btn-block btn-signup mt-4"
-      #password-edit.tab-pane.fade.col-12
-        = form_for(@user, url: update_password_path(params[:id]), html: {id: "user_edit_2"}) do |f|
-          = render "shared/error_messages", object: f.object
-          = f.password_field :current_password, required: true, class: "form-control placeholder mt-5 mb-4", placeholder: "現在のパスワード"
-
-          = f.password_field :password, required: true, maxlength: 50, class: "form-control placeholder mb-4", placeholder: "新しいパスワード（６文字以上）"
-
-          = f.password_field :password_confirmation, required: true, maxlength: 50, class: "form-control placeholder", placeholder: "新しいパスワード（確認）"
-
-          = f.submit "パスワードを更新する", class: "btn btn-info btn-block btn-signup mt-4"
-  = link_to "アカウントを削除する場合はこちらから", delete_page_path(@user), class: "invite-text invite-delete text-center"
+    - if @user.provider == "twitter"
+      = render "edit_form_for_twitter", user: @user
+    - else
+      = render "edit_form", user: @user
+  = link_to "アカウントを削除する場合はこちらから", delete_page_path(@user), class: "invite-text invite-delete text-center mb-5"


### PR DESCRIPTION
close #104 

## 概要
- ヘッダーの項目を変更
  - マイページ→自分ルール一覧
  - ユーザー名のドロップダウンを設置し、編集とログアウト
- ツイッターログインのユーザーはヘッダーにプロフィール写真を表示
- ツイッターログインユーザーはユーザー名のみ編集できるように変更

## テスト内容
- chromeの検証機能で表示を確認
- ツイッターログインかどうかで表示が変わることを確認
  - ヘッダーと編集ページ
- プロフィール編集を問題なく行えることを確認

## 参考URL
- [Bootstrapのdropdownを親要素の右基準にする](https://teratail.com/questions/132451)