### PR TITLE
iOSでドロップダウンが機能するようにする（＋細かい修正）

### DIFF
--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -13,12 +13,13 @@
             %li.nav-item
               = link_to "自分ルール一覧", current_user, class: "nav-link"
             %li.nav-item.dropdown
-              %a.nav-link.dropdown-toggle#navbarDropdown{"data-toggle" => "dropdown", "role" => "button", "aria-haspopup" => "true", "aria-expanded" => "false"}
+              %a.nav-link.dropdown-toggle#navbarDropdown{"href" => "#", "data-toggle" => "dropdown", "role" => "button", "aria-haspopup" => "true", "aria-expanded" => "false"}
                 - if current_user.provider == "twitter"
                   %img.user-img{src: current_user.image_url}
-                %span.user-name
-                  = current_user.name
+                = current_user.name
               .dropdown-menu.dropdown-menu-right{"aria-haspopup" => "true"}
+                - if current_user.admin?
+                  = link_to "管理ページ", admin_users_path, class: "dropdown-item"
                 = link_to "プロフィール編集", edit_user_path(current_user), class: "dropdown-item"
                 = link_to "ログアウト", logout_path, method: "delete", class: "dropdown-item"
           - else


### PR DESCRIPTION
issue #92 

## 概要
- トグラーにhrefを指定する
- 管理ユーザーはヘッダーに管理ページへのリンクが表示されるようにする
- いらないclassの削除

## テスト内容
- トピックブランチをデプロイして実機でドロップダウンが機能していることを確認
- 管理ユーザーのヘッダーには管理ページへのリンクが表示されることを確認

## 参考URL
https://stackoverflow.com/questions/20960405/bootstrap-3-dropdown-on-ipad-not-working