### PR TITLE
セキュリティ強化

### DIFF
--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -10,7 +10,7 @@ class PasswordResetsController < ApplicationController
     @email = params[:password_reset][:email]
     @user = User.find_by(email: @email.downcase)
     unless @user
-      flash.now[:danger] = "メールアドレスが間違っています"
+      flash.now[:danger] = "メールアドレスが間違っているかアカウントが有効化されていません"
       render :new and return
     end
     if @user.activated
@@ -19,7 +19,7 @@ class PasswordResetsController < ApplicationController
       flash[:info] = "メールを送信しました"
       redirect_to root_url
     else
-      flash.now[:danger] = "アカウントが有効化されていません"
+      flash.now[:danger] = "メールアドレスが間違っているかアカウントが有効化されていません"
       render :new
     end
   end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,19 +1,24 @@
 class SessionsController < ApplicationController
   before_action :forbid_login_user, only: [:new, :create]
+  before_action :set_user, only: [:create]
+  before_action :check_locked, only: [:create]
 
   def new
   end
 
   def create
-    @email = params[:session][:email]
-    user = User.find_by(email: @email.downcase)
-    if user && user.authenticate(params[:session][:password])
-      log_in user
-      (params[:session][:remember_me] == "1") ? remember(user) : forget(user)
-      user.admin? ? redirect_to(admin_users_path) : redirect_back_or(user)
+    if @user && @user.authenticate(params[:session][:password])
+      log_in @user
+      (params[:session][:remember_me] == "1") ? remember(@user) : forget(@user)
+      @user.admin? ? redirect_to(admin_users_path) : redirect_back_or(@user)
       flash[:info] = "ログインしました"
     else
-      flash.now[:danger] = "メールアドレスかパスワードが間違っています"
+      @user.fail_login if @user
+      flash.now[:danger] = if @user.locked?
+                             "アカウントがロックされました。30分後に解除されます。"
+                           else
+                             "メールアドレスかパスワードが間違っています"
+                           end
       render :new
     end
   end
@@ -23,4 +28,18 @@ class SessionsController < ApplicationController
     flash[:info] = "ログアウトしました"
     redirect_to root_url
   end
+
+  private
+
+    def set_user
+      @email = params[:session][:email]
+      @user = User.find_by(email: @email.downcase)
+    end
+
+    def check_locked
+      if @user && @user.locked?
+        flash.now[:warning] = "アカウントがロックされています。解除されるまでしばらくお待ちください。"
+        render :new
+      end
+    end
 end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -1,6 +1,7 @@
 module SessionsHelper
   def log_in(user)
     session[:user_id] = user.id
+    user.update!({ failed_attempts: 0 })
   end
 
   def remember(user)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -92,6 +92,20 @@ class User < ApplicationRecord
     reset_sent_at < 2.hours.ago
   end
 
+  def fail_login
+    update!({ failed_attempts: failed_attempts + 1 })
+    if failed_attempts >= 5
+      update!({
+        locked_at: Time.current,
+        failed_attempts: 0,
+      })
+    end
+  end
+
+  def locked?
+    locked_at && (Time.current < locked_at + 30.minutes)
+  end
+
   private
 
     def downcase_email

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,7 @@ module MakeHabits
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
     config.time_zone = "Asia/Tokyo"
+    config.active_record.default_timezone = :local
     config.action_view.embed_authenticity_token_in_remote_forms = true
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,0 +1,1 @@
+Rails.application.config.session_store :cookie_store, key: "_make_habits_session", expire_after: 2.hours

--- a/db/migrate/20190323044249_add_columns_to_users.rb
+++ b/db/migrate/20190323044249_add_columns_to_users.rb
@@ -1,0 +1,6 @@
+class AddColumnsToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :failed_attempts, :integer, default: 0, null: false
+    add_column :users, :locked_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_16_083639) do
+ActiveRecord::Schema.define(version: 2019_03_23_044249) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -42,6 +42,8 @@ ActiveRecord::Schema.define(version: 2019_03_16_083639) do
     t.string "uid"
     t.string "image_url"
     t.boolean "admin", default: false
+    t.integer "failed_attempts", default: 0, null: false
+    t.datetime "locked_at"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 


### PR DESCRIPTION
close #88 

## 概要
- セッションの有効期限を2時間に設定
- フラッシュのメッセージを修正
  - フラッシュで余計な情報を与えないようにすることがセキュリティ上大事
- アカウントロック機能の実装
  - ５回連続でパスワード間違えたら30分アカウントをロックする
- herokuのタイムゾーンを設定

## テスト内容
- 操作せずに放置するとセッションが切れることを確認
- ５回連続でパスワードを間違えるとアカウントがロックされることを確認
  - 操作確認時はセッションが切れるまでの時間やアカウントがロックされる時間を短くして確認
- トピックブランチをデプロイして本番環境でも動作することを確認

## 補足
- 時間の不等号での比較は未来の方が大きい
  - `昨日 < 今日`が正しい
  - 不等号の向きを`<`に固定して右に行くほど未来ってやるとわかりやすい

- フォームを表示させたままセッションが切れるとCSRFのエラーが出る
  - 動作確認中はセッションがすぐ切れるようにしてたから、アカウントロックが解除されるまでにセッションが切れて`Can't verify CSRF token authenticity.`のエラーが
 - 時刻情報使う場合はタイムゾーン設定を忘れずに

## 参考URL
- [Railsアプリで実際にあった5つのセキュリティ問題と修正方法（翻訳）](https://techracho.bpsinc.jp/hachi8833/2018_10_23/62858)
- [Rails + Heroku 利用時に、レコードのタイムゾーンがずれていることに気が付いた際に確認したいこと & リカバリ方法](https://qiita.com/tetsuya/items/e0fd25fc3da2615d1cb2)
- [RubyとRailsにおけるTime, Date, DateTime, TimeWithZoneの違い](https://qiita.com/jnchito/items/cae89ee43c30f5d6fa2c)