### PR TITLE
アカウント有効化メールの再送信ページの作成

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -180,14 +180,17 @@ header {
   @include form-divide(100px)
 }
 
-// password reset
-.password-reset-wrapper {
+// password reset, account activation
+.password-reset-wrapper, .account-activation-wrapper {
   max-width: 800px;
   .heading {
     font-weight: 600;
     border-bottom: .7px solid #ccc;
     margin: 3rem 0 2rem;
     padding-bottom: .7rem
+  }
+  p {
+    line-height: 2.5;
   }
 }
 
@@ -500,7 +503,7 @@ footer {
     margin-top: 1.2rem;
     font-size: .7rem;
   }
-  .password-reset-wrapper {
+  .password-reset-wrapper, .account-activation-wrapper {
     h2 {
       font-size: 1.5rem;
     }

--- a/app/controllers/account_activations_controller.rb
+++ b/app/controllers/account_activations_controller.rb
@@ -1,4 +1,24 @@
 class AccountActivationsController < ApplicationController
+  def new
+  end
+
+  def create
+    @email = params[:account_activation][:email]
+    @user = User.find_by(email: @email.downcase)
+    unless @user
+      flash.now[:warning] = "メールアドレスが間違っているかすでに有効化されています"
+      render :new and return
+    end
+    if @user.activated?
+      flash.now[:warning] = "メールアドレスが間違っているかすでに有効化されています"
+      render :new
+    else
+      @user.resend_activation_email
+      flash[:info] = "メールを送信しました"
+      redirect_to root_url
+    end
+  end
+
   def edit
     user = User.find_by(email: params[:email])
     if user && !user.activated? && user.authenticated?(:activation, params[:id])

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -2,17 +2,12 @@ class PasswordResetsController < ApplicationController
   before_action :set_user, only: [:edit, :update]
   before_action :valid_user, only: [:edit, :update]
   before_action :check_expiration, only: [:edit, :update]
+  before_action :check_user_existence, only: [:create]
 
   def new
   end
 
   def create
-    @email = params[:password_reset][:email]
-    @user = User.find_by(email: @email.downcase)
-    unless @user
-      flash.now[:danger] = "メールアドレスが間違っているかアカウントが有効化されていません"
-      render :new and return
-    end
     if @user.activated
       @user.create_reset_digest
       @user.send_password_reset_email
@@ -65,6 +60,15 @@ class PasswordResetsController < ApplicationController
       if @user.password_reset_expired?
         flash[:danger] = "リンクの有効期限が切れています"
         redirect_to new_password_reset_url
+      end
+    end
+
+    def check_user_existence
+      @email = params[:password_reset][:email]
+      @user = User.find_by(email: @email.downcase)
+      unless @user
+        flash.now[:danger] = "メールアドレスが間違っているかアカウントが有効化されていません"
+        render :new
       end
     end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -46,7 +46,7 @@ class UsersController < ApplicationController # rubocop:disable Metrics/ClassLen
     @user = User.find(params[:id])
     before_change_email = @user.email
     if @user.update(user_params)
-      @user.reactivate unless @user.email == before_change_email
+      @user.resend_activation_email unless @user.email == before_change_email
       flash[:success] = "プロフィールを更新しました"
       redirect_to @user
     else

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -73,7 +73,7 @@ class User < ApplicationRecord
     UserMailer.account_activation(self).deliver_now
   end
 
-  def reactivate
+  def resend_activation_email
     update_attribute(:activated, false) # rubocop:disable Rails/SkipsModelValidations
     create_activation_digest and self.save
     send_activation_email

--- a/app/views/account_activations/new.html.haml
+++ b/app/views/account_activations/new.html.haml
@@ -1,0 +1,15 @@
+.container.account-activation-wrapper
+  .row
+    .col-sm-10.offset-sm-1
+      %h2.heading
+        有効化メールを再送信
+      %p
+        アカウント登録時に送信されるメールからアカウントを有効化してください。
+      %p
+        下のフォームからアカウント有効化メールを再送信することも可能です。
+      %p
+        登録したメールアドレスを入力してください。
+      = form_for(:account_activation, url: account_activations_path) do |f|
+        = f.email_field :email, required: true, class: "form-control placeholder my-4", placeholder: "メールアドレス", value: "#{@email}"
+        %div
+          = f.submit "メールを送信する", class: "btn btn-secondary mt-2"

--- a/app/views/password_resets/new.html.haml
+++ b/app/views/password_resets/new.html.haml
@@ -8,7 +8,7 @@
       %p
         パスワード変更ページのURLを記載したメールを送信します。
       = form_for(:password_reset, url: password_resets_path) do |f|
-        = f.email_field :email, required: true, class: "form-control placeholder mt-3", placeholder: "メールアドレス", value: "#{@email}"
+        = f.email_field :email, required: true, class: "form-control placeholder my-4", placeholder: "メールアドレス", value: "#{@email}"
         %div
-          = f.submit "メールを送信する", class: "btn btn-secondary mt-4"
-        = link_to "ログインはこちら", login_path, class: "invite-text display-block"
+          = f.submit "メールを送信する", class: "btn btn-secondary mt-2"
+        = link_to "アカウントが有効化されていない場合はこちら", new_account_activation_path, class: "invite-text display-block mt-4 mb-5"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
   get "/users/:id/delete", to: "users#delete", as: "delete_page"
   resources :users, except: [:index, :update]
 
-  resources :account_activations, only: [:edit]
+  resources :account_activations, only: [:new, :create, :edit]
   resources :password_resets, only: [:new, :create, :edit, :update]
 
   resources :habits, only: [:destroy]


### PR DESCRIPTION
close #31 

## 概要
- アカウント有効化メールの再送信ページを実装
  - パスワードリセットページから再有効化ページへの導線を追加
- メソッド名をわかりやすいように変更
- sessionsコントローラーのバグ（間違ったアドレスを弾けていなかった）を修正
  - ユーザーの存在検証をbefore_actionに切り出した
  - 同様の処理をpassword_resetsコントローラーでも実装

## テスト内容
- 間違ったアドレスでログインしようとした際のバグが修正されていることを確認
- アカウント有効化メール再送信画面の挙動が正しいことを確認
  - 間違ったアドレスは弾かれる
  - すでに有効化されているアドレスは弾かれる
  - 登録されていて有効化されていないアドレスが入力されるとメールが送信される
  - メールを再送信すると、それ以前に送られたメールのリンクが無効になる
- 本番環境でも動作することをトピックブランチをデプロイして確認