### PR TITLE
gemのアップデート

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ gem "erb2haml"
 gem "haml-rails"
 
 # bootstrap
-gem "bootstrap", "~> 4.1.1"
+gem "bootstrap", "~> 4.3.1"
 gem "font-awesome-sass", "~> 5.6.1"
 gem "jquery-rails"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,7 +48,7 @@ GEM
       io-like (~> 0.3.0)
     arel (9.0.0)
     ast (2.4.0)
-    autoprefixer-rails (9.4.9)
+    autoprefixer-rails (9.5.0)
       execjs
     bcrypt (3.1.12)
     better_errors (2.5.1)
@@ -60,10 +60,10 @@ GEM
       debug_inspector (>= 0.0.1)
     bootsnap (1.4.1)
       msgpack (~> 1.0)
-    bootstrap (4.1.3)
-      autoprefixer-rails (>= 6.0.3)
-      popper_js (>= 1.12.9, < 2)
-      sass (>= 3.5.2)
+    bootstrap (4.3.1)
+      autoprefixer-rails (>= 9.1.0)
+      popper_js (>= 1.14.3, < 2)
+      sassc-rails (>= 2.0.0)
     builder (3.2.3)
     byebug (11.0.0)
     capybara (3.14.0)
@@ -261,6 +261,12 @@ GEM
     sassc (2.0.1)
       ffi (~> 1.9)
       rake
+    sassc-rails (2.1.0)
+      railties (>= 4.0.0)
+      sassc (>= 2.0)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     selenium-webdriver (3.141.0)
       childprocess (~> 0.5)
       rubyzip (~> 1.2, >= 1.2.2)
@@ -309,7 +315,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   bootsnap (>= 1.1.0)
-  bootstrap (~> 4.1.1)
+  bootstrap (~> 4.3.1)
   capybara (>= 2.15)
   chromedriver-helper
   coffee-rails (~> 4.2)


### PR DESCRIPTION
close #110 

## 概要
- githubでアラートのでていたgem(bootstrap)をアップデート

## テスト内容
- 表示崩れがないことを確認
- 本番環境でも表示崩れがないことを確認
- iPhoneとiPadでの表示を実機で確認

## 参考URL
- [bootstrap-rubygem](https://github.com/twbs/bootstrap-rubygem)