### PR TITLE
ルール一覧ページの見た目の変更とルール作成ページにステップバーを追加

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -291,6 +291,50 @@ header {
 
 // makes new, quits new
 .makes-new-wrapper, .quits-new-wrapper {
+  .step-bar {
+    display: flex;
+    max-width: 700px;
+    position: relative;
+    margin: 3.5rem auto 1.5rem;
+    padding: 0;
+    text-align: center;
+  }
+  .step-bar li {
+    font-size: 12px;
+    list-style: none;
+    position: relative;
+    width: 33.333%;
+  }
+  .step-bar li:after {
+    background: #D0E1F9;
+    content: "";
+    width: calc(100% - 24px);
+    height: 4px;
+    position: absolute;
+    left: calc(-50% + 12px);
+    top: 10px;
+  }
+  .step-bar li:first-child:after {
+    display: none;
+  }
+  .step-bar li span {
+    background: #D0E1F9;
+    color: #ffffff;
+    display: inline-block;
+    height: 24px;
+    margin-bottom: 5px;
+    line-height: 24px;
+    width: 24px;
+    -moz-border-radius: 50%;
+    -webkit-border-radius: 50%;
+    border-radius: 50%;
+  }
+  .step-bar .visited:after {
+    background: #4D648D;
+  }
+  .step-bar .visited span {
+    background: #4D648D;
+  }
   .jumbotron {
     background-color: #f8f8f8;
     box-shadow: 0 3px 3px rgba(0, 0, 0, 0.3);
@@ -608,6 +652,9 @@ footer {
     }
   }
   .makes-new-wrapper, .quits-new-wrapper {
+    .step-bar li {
+      font-size: .7rem;
+    }
     .form-control, .btn{
       width: 100%;
     }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -391,22 +391,25 @@ header {
     font-size: 2rem;
     opacity: 0.7;
   }
+  .nav-tabs {
+    border-bottom: none;
+    .nav-item {
+      width : 25%;
+      .nav-link {
+        border-radius: .25rem;
+        text-align: center;
+        border: 1px solid #17A2B8;
+        color: #17A2B8;
+        &.active {
+          background-color: #17A2B8;
+          color: white;
+        }
+      }
+    }
+  }
   .jumbotron {
     background-color: #f8f8f8;
     box-shadow: 0 3px 3px rgba(0, 0, 0, 0.3);
-    .nav-item {
-      width : 33.33333%; /* 未対応ブラウザ用フォールバック */
-      width : -webkit-calc(100% / 3);
-      width : calc(100% / 3);
-      a {
-        color: black;
-      }
-    }
-    .nav-link {
-      height: 100%;
-      padding: 1.5rem;
-      text-align: center;
-    }
     .rule-empty-text {
       font-size: 1.5rem;
       padding: 3rem;
@@ -574,6 +577,13 @@ footer {
     h1 {
       font-size: 1.5rem;
     }
+    .nav-tabs {
+      .nav-item {
+        a {
+          font-size: .9rem;
+        }
+      }
+    }
     .jumbotron {
       .rule-empty-text {
         font-size: 1.2rem;
@@ -638,6 +648,17 @@ footer {
   .user-show-wrapper {
     h1 {
       font-size: 1.2rem;
+    }
+    .nav-tabs {
+      .nav-item {
+        width : 30%;
+        a {
+          font-size: .7rem;
+        }
+        .nav-link {
+          padding: .5rem;
+        }
+      }
     }
     .jumbotron {
       .nav-item {

--- a/app/views/makes/new1.html.haml
+++ b/app/views/makes/new1.html.haml
@@ -1,5 +1,6 @@
 .container.makes-new-wrapper
-  .jumbotron.mt-5.text-center
+  = render "shared/stepbar", step: 1, type: "make"
+  .jumbotron.text-center
     = link_to "javascript:void(0);", onclick: "history.back()", class: "back-icon" do
       = icon("fa", "arrow-left")
     %p.lead

--- a/app/views/makes/new3.html.haml
+++ b/app/views/makes/new3.html.haml
@@ -1,5 +1,6 @@
 .container.makes-new-wrapper.text-center
-  .jumbotron.mt-5
+  = render "shared/stepbar", step: 2, type: "make"
+  .jumbotron
     = link_to "javascript:void(0);", onclick: "history.back()", class: "back-icon" do
       = icon("fa", "arrow-left")
 

--- a/app/views/makes/new5.html.haml
+++ b/app/views/makes/new5.html.haml
@@ -1,5 +1,6 @@
 .container.makes-new-wrapper.text-center
-  .jumbotron.mt-5
+  = render "shared/stepbar", step: 3, type: "make"
+  .jumbotron
     = link_to "javascript:void(0);", onclick: "history.back()", class: "back-icon" do
       = icon("fa", "arrow-left")
 

--- a/app/views/makes/new7.html.haml
+++ b/app/views/makes/new7.html.haml
@@ -1,5 +1,6 @@
 .container.makes-new-wrapper
-  .jumbotron.mt-5.text-center
+  = render "shared/stepbar", step: 4, type: "make"
+  .jumbotron.text-center
     = link_to "javascript:void(0);", onclick: "history.back()", class: "back-icon" do
       = icon("fa", "arrow-left")
     %p.lead

--- a/app/views/makes/new9.html.haml
+++ b/app/views/makes/new9.html.haml
@@ -1,5 +1,6 @@
 .container.makes-new-wrapper.text-center
-  .jumbotron.mt-5
+  = render "shared/stepbar", step: 5, type: "make"
+  .jumbotron
     = link_to "javascript:void(0);", onclick: "history.back()", class: "back-icon" do
       = icon("fa", "arrow-left")
     %p.lead

--- a/app/views/quits/new1.html.haml
+++ b/app/views/quits/new1.html.haml
@@ -1,5 +1,6 @@
 .container.quits-new-wrapper
-  .jumbotron.mt-5.text-center
+  = render "shared/stepbar", step: 1, type: "quit"
+  .jumbotron.text-center
     = link_to "javascript:void(0);", onclick: "history.back()", class: "back-icon" do
       = icon("fa", "arrow-left")
     %p.lead

--- a/app/views/quits/new3.html.haml
+++ b/app/views/quits/new3.html.haml
@@ -1,5 +1,6 @@
 .container.quits-new-wrapper
-  .jumbotron.mt-5.text-center
+  = render "shared/stepbar", step: 2, type: "quit"
+  .jumbotron.text-center
     = link_to "javascript:void(0);", onclick: "history.back()", class: "back-icon" do
       = icon("fa", "arrow-left")
     %p.lead

--- a/app/views/quits/new5.html.haml
+++ b/app/views/quits/new5.html.haml
@@ -1,5 +1,6 @@
 .container.quits-new-wrapper.text-center
-  .jumbotron.mt-5
+  = render "shared/stepbar", step: 3, type: "quit"
+  .jumbotron
     = link_to "javascript:void(0);", onclick: "history.back()", class: "back-icon" do
       = icon("fa", "arrow-left")
     %p.lead

--- a/app/views/quits/new7.html.haml
+++ b/app/views/quits/new7.html.haml
@@ -1,5 +1,6 @@
 .container.quits-new-wrapper.text-center
-  .jumbotron.mt-5
+  = render "shared/stepbar", step: 4, type: "quit"
+  .jumbotron
     = link_to "javascript:void(0);", onclick: "history.back()", class: "back-icon" do
       = icon("fa", "arrow-left")
     %p.lead

--- a/app/views/shared/_stepbar.html.haml
+++ b/app/views/shared/_stepbar.html.haml
@@ -1,0 +1,22 @@
+%nav
+  %ol.step-bar
+    %li.visited<
+      %span<
+        1
+      %br step1
+    %li{class: "#{'visited' if step >= 2}"}<
+      %span<
+        2
+      %br step2
+    %li{class: "#{'visited' if step >= 3}"}<
+      %span<
+        3
+      %br step3
+    %li{class: "#{'visited' if step >= 4}"}<
+      %span<
+        4
+      %br step4
+    %li{class: "#{'visited' if step >= 5} #{'d-none' if type == "quit"}"}<
+      %span<
+        5
+      %br step5

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,14 +1,14 @@
 .container.user-show-wrapper
   %h1.text-center.my-5
     = "自分ルール一覧"
+  %ul.nav.nav-tabs.d-flex.justify-content-between
+    %li.nav-item
+      %a.nav-link.active{"href" => "#tab1", "data-toggle" => "tab"} すべて
+    %li.nav-item
+      %a.nav-link{"href" => "#tab2", "data-toggle" => "tab"} 身につけたい
+    %li.nav-item
+      %a.nav-link{"href" => "#tab3", "data-toggle" => "tab"} やめたい
   .jumbotron.mt-5.mx-auto.p-0
-    %ul.nav.nav-tabs
-      %li.nav-item
-        %a.nav-link.active{"href" => "#tab1", "data-toggle" => "tab"} すべて
-      %li.nav-item
-        %a.nav-link.border-left.border-right{"href" => "#tab2", "data-toggle" => "tab"} 身につけたい
-      %li.nav-item
-        %a.nav-link{"href" => "#tab3", "data-toggle" => "tab"} やめたい
     .tab-content
       #tab1.tab-pane.active
         - if @user.habits.empty?


### PR DESCRIPTION
issue #23 

## 概要
- ルール一覧ページのタブ部分のデザインを変更
- ルール作成ページにステップバーを追加
  - 書き方は[このサイト](https://works.coldsleep.jp/blog/css-stepbar/)から拝借

## テスト内容
- ステップバーがページに応じてきちんと進んでいくことを確認
- トピックブランチをデプロイして実機で表示を確認

## 参考URL
- [CSSだけで作るステップバー](https://works.coldsleep.jp/blog/css-stepbar/)
- [hamlでの後置ifの書き方](http://d.hatena.ne.jp/ken_c_lo/20130811/1376216598)