### PR TITLE
habitモデルにprogressのバリデーションを追加する

### DIFF
--- a/app/models/habit.rb
+++ b/app/models/habit.rb
@@ -5,6 +5,8 @@ class Habit < ApplicationRecord
   validates :rule2, presence: true, length: { maximum: 255 }
   validates :type, presence: true
   validates :user_id, presence: true
+  validates :progress, presence: true,
+                       numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 100 }
 
   belongs_to :user
 end

--- a/spec/factories/habits.rb
+++ b/spec/factories/habits.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
     title { "筋トレをする" }
     rule1 { "歯磨きをしたら１回スクワットをする" }
     rule2 { "めんどくさいと思ったら太ってる自分の写真を見返す" }
+    progress { 33 }
     user
   end
 
@@ -12,6 +13,7 @@ FactoryBot.define do
     title { "間食をする" }
     rule1 { "仕事中はガムを噛む" }
     rule2 { "お菓子のストックはやめて食べる時は毎回コンビニに行く" }
+    progress { 100 }
     user
   end
 end

--- a/spec/models/habit_spec.rb
+++ b/spec/models/habit_spec.rb
@@ -57,5 +57,22 @@ RSpec.describe Habit, type: :model do
         expect(habit).not_to be_valid
       end
     end
+
+    context "progressが無効な場合" do
+      it "存在しない場合" do
+        habit.progress = nil
+        expect(habit).not_to be_valid
+      end
+
+      it "浮動小数の場合" do
+        habit.progress = 63.4
+        expect(habit).not_to be_valid
+      end
+
+      it "0以上100以下ではない整数の場合" do
+        habit.progress = 235
+        expect(habit).not_to be_valid
+      end
+    end
   end
 end


### PR DESCRIPTION
close #121 

## 概要
- バリデーションの記述
- model specにprogressに関する記述を追加

## テスト内容
- コンソール上でバリデーションが機能していることを確認
  - 0~100以外の数字, 小数, 文字列などが弾かれる
- rspecがパスすることを確認

## 補足
- 進捗のプログレスバーをCapybaraで操作する方法が分からなかったので、system specの編集に関するテストは実装できてない

## 参考URL
- [検証(validation)](http://railsdoc.com/validation)