### PR TITLE
binstubとwebdriversのセットアップ

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,14 +73,14 @@ group :development do
   # Make errors understandable
   gem "better_errors"
   gem "binding_of_caller"
+  gem "spring-commands-rspec"
 end
 
 group :test do
   # Adds support for Capybara system testing and selenium driver
   gem "capybara", ">= 2.15"
   gem "selenium-webdriver"
-  # Easy installation and use of chromedriver to run system tests with Chrome
-  gem "chromedriver-helper"
+  gem "webdrivers"
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,8 +44,6 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
-    archive-zip (0.11.0)
-      io-like (~> 0.3.0)
     arel (9.0.0)
     ast (2.4.0)
     autoprefixer-rails (9.5.0)
@@ -76,9 +74,6 @@ GEM
       xpath (~> 3.2)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
-    chromedriver-helper (2.1.0)
-      archive-zip (~> 0.10)
-      nokogiri (~> 1.8)
     coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
@@ -127,7 +122,6 @@ GEM
       ruby_parser (~> 3.5)
     i18n (1.5.3)
       concurrent-ruby (~> 1.0)
-    io-like (0.3.0)
     jaro_winkler (1.5.2)
     jbuilder (2.8.0)
       activesupport (>= 4.2.0)
@@ -166,6 +160,7 @@ GEM
     minitest (5.11.3)
     msgpack (1.2.6)
     multi_json (1.13.1)
+    net_http_ssl_fix (0.0.10)
     nio4r (2.3.1)
     nokogiri (1.10.1)
       mini_portile2 (~> 2.4.0)
@@ -296,6 +291,8 @@ GEM
     sexp_processor (4.11.0)
     spring (2.0.2)
       activesupport (>= 4.2)
+    spring-commands-rspec (1.0.4)
+      spring (>= 0.9.1)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
       spring (>= 1.2, < 3.0)
@@ -323,6 +320,11 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
+    webdrivers (3.7.1)
+      net_http_ssl_fix
+      nokogiri (~> 1.6)
+      rubyzip (~> 1.0)
+      selenium-webdriver (~> 3.0)
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
@@ -340,7 +342,6 @@ DEPENDENCIES
   bootsnap (>= 1.1.0)
   bootstrap (~> 4.3.1)
   capybara (>= 2.15)
-  chromedriver-helper
   coffee-rails (~> 4.2)
   erb2haml
   factory_bot_rails (~> 4.11)
@@ -366,11 +367,13 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   selenium-webdriver
   spring
+  spring-commands-rspec
   spring-watcher-listen (~> 2.0.0)
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
+  webdrivers
 
 RUBY VERSION
    ruby 2.5.1p57

--- a/bin/rspec
+++ b/bin/rspec
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+begin
+  load File.expand_path("spring", __dir__)
+rescue LoadError => e
+  raise unless e.message.include?("spring")
+end
+require "bundler/setup"
+load Gem.bin_path("rspec-core", "rspec")


### PR DESCRIPTION
close #126 

close #124 

## 概要
- binstubのセットアップ
  - テストスイートの起動時間をはやくする
- chromedriver-helperからwebdrivers gemに移行
  - chromedriver-helperのサポートが終了するため

## テスト内容
- `bin/rspec`コマンドでテストを実行できることを確認
- 既存のテストが実行できることを確認

## 補足
-webdriversにすると実行時間が長くなってしまうけど現時点では仕方ないっぽい

## 参考URL
- [サポートが終了したchromedriver-helperからwebdrivers gemに移行する手順](https://qiita.com/jnchito/items/f9c3be449fd164176efa)
- everyday rails p14