### PR TITLE
simplecovのインストール

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master-test.key
+
+coverage

--- a/Gemfile
+++ b/Gemfile
@@ -81,6 +81,7 @@ group :test do
   gem "capybara", ">= 2.15"
   gem "selenium-webdriver"
   gem "webdrivers"
+  gem 'simplecov', require: false
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,7 @@ GEM
     crass (1.0.4)
     debug_inspector (0.0.3)
     diff-lcs (1.3)
+    docile (1.3.1)
     erb2haml (0.1.5)
       html2haml
     erubi (1.8.0)
@@ -130,6 +131,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    json (2.2.0)
     kaminari (1.1.1)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.1.1)
@@ -289,6 +291,11 @@ GEM
       childprocess (~> 0.5)
       rubyzip (~> 1.2, >= 1.2.2)
     sexp_processor (4.11.0)
+    simplecov (0.16.1)
+      docile (~> 1.1)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
     spring (2.0.2)
       activesupport (>= 4.2)
     spring-commands-rspec (1.0.4)
@@ -366,6 +373,7 @@ DEPENDENCIES
   rubocop
   sass-rails (~> 5.0)
   selenium-webdriver
+  simplecov
   spring
   spring-commands-rspec
   spring-watcher-listen (~> 2.0.0)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,9 @@
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 
 require "capybara/rspec"
+require "simplecov"
+
+SimpleCov.start "rails"
 
 RSpec.configure do |config|
   config.before(:each, type: :system) do


### PR DESCRIPTION
close #118 

## 概要
- [simplecov](https://github.com/colszowka/simplecov)のインストール

## テスト内容
- rspecを走らせるとcoverage配下にカバー率が記載されたHTMLが作られることを確認

## 補足
- 最初はこのissueでrequest spec書く予定だったけどカバー率見た感じ system specをもうちょい網羅的書いて（アカウント有効化, パスワードリセットとか）、拾いきれなかったものをrequest specとかmodel specとかで書くほうがいいと思ったから方向転換
- とりあえずテスト技法（RSpecの文法ではなく）は１回ちゃんと勉強したほうがいい

## 参考URL
- [simplecov](https://github.com/colszowka/simplecov)