### PR TITLE
パスワードリセットとアカウント有効化のテストを追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -80,8 +80,8 @@ group :test do
   # Adds support for Capybara system testing and selenium driver
   gem "capybara", ">= 2.15"
   gem "selenium-webdriver"
+  gem "simplecov", require: false
   gem "webdrivers"
-  gem 'simplecov', require: false
 end
 
 group :development, :test do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -11,4 +11,11 @@ FactoryBot.define do
     password { "password" }
     admin { true }
   end
+
+  factory :activated_user, class: User do
+    name { "有効化されているユーザー" }
+    email { "activated@example.com" }
+    password { "password" }
+    activated { true }
+  end
 end

--- a/spec/support/utilities.rb
+++ b/spec/support/utilities.rb
@@ -23,7 +23,7 @@ def login_as(user, options = {})
   if options[:no_capybara]
     # Capybaraを使用していない場合でもログインできるようにする
     remember_token = User.new_token
-    user.update_attribute(:remember_digest, User.digest(remember_token))
+    user.update!({ remember_digest: User.digest(remember_token) })
     test_cookies = ActionDispatch::Request.new(Rails.application.env_config.deep_dup).cookie_jar
     test_cookies.signed[:user_id] = user.id
     cookies[:user_id] = test_cookies[:user_id]

--- a/spec/support/utilities.rb
+++ b/spec/support/utilities.rb
@@ -19,9 +19,19 @@ def set_omniauth
   })
 end
 
-def login_as(user)
-  visit login_path
-  fill_in "session[email]", with: user.email
-  fill_in "session[password]", with: user.password
-  click_button "ログイン"
+def login_as(user, options = {})
+  if options[:no_capybara]
+    # Capybaraを使用していない場合でもログインできるようにする
+    remember_token = User.new_token
+    user.update_attribute(:remember_digest, User.digest(remember_token))
+    test_cookies = ActionDispatch::Request.new(Rails.application.env_config.deep_dup).cookie_jar
+    test_cookies.signed[:user_id] = user.id
+    cookies[:user_id] = test_cookies[:user_id]
+    cookies[:remember_token] = remember_token
+  else
+    visit login_path
+    fill_in "session[email]", with: user.email
+    fill_in "session[password]", with: user.password
+    click_button "ログイン"
+  end
 end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 describe "ユーザー機能", type: :system do
   let!(:user) { FactoryBot.create(:user) }
+  let(:other_user) { FactoryBot.create(:user, name: "他のユーザー", email: "other_user@example.com") }
   let(:admin_user) { FactoryBot.create(:admin_user) }
 
   describe "新規登録機能（メールアドレス）" do
@@ -24,8 +25,9 @@ describe "ユーザー機能", type: :system do
     end
 
     context "ユーザーの入力が空のとき" do
-      it "ユーザー登録に失敗する" do
-        expect { click_button submit }.not_to change { User.count }
+      it "リクエストを送信できない" do
+        click_button submit
+        expect(page).to have_current_path signup_path
       end
     end
   end
@@ -73,6 +75,12 @@ describe "ユーザー機能", type: :system do
     before do
       login_as user
       visit edit_user_path(user)
+    end
+
+    it "他のユーザーの編集ページにはアクセスできない" do
+      visit edit_user_path(other_user)
+      expect(page).not_to have_current_path edit_user_path(other_user)
+      expect(page).to have_current_path user_path(user)
     end
 
     describe "ユーザー名/メールアドレス編集" do
@@ -173,6 +181,11 @@ describe "ユーザー機能", type: :system do
         within ".alert" do
           expect(page).to have_content "アカウントを削除しました"
         end
+      end
+
+      it "他のユーザーのアカウント削除ページにはアクセスできない" do
+        visit delete_page_path(other_user)
+        expect(page).not_to have_current_path delete_page_path(other_user)
       end
     end
 

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -3,7 +3,11 @@ require "rails_helper"
 describe "ユーザー機能", type: :system do
   let!(:user) { FactoryBot.create(:user) }
   let(:other_user) { FactoryBot.create(:user, name: "他のユーザー", email: "other_user@example.com") }
+  let(:activated_user) { FactoryBot.create(:activated_user) }
   let(:admin_user) { FactoryBot.create(:admin_user) }
+
+  let(:activation_mail) { ActionMailer::Base.deliveries.last }
+  let(:password_reset_mail) { ActionMailer::Base.deliveries.last }
 
   describe "新規登録機能（メールアドレス）" do
     let(:submit) { "新規登録" }
@@ -21,6 +25,13 @@ describe "ユーザー機能", type: :system do
       it "ユーザー登録が成功する" do
         expect { click_button submit }.to change { User.count }.by(1)
         expect(page).to have_selector ".alert-success", text: "ユーザー登録しました"
+      end
+
+      it "ユーザーにアカウント有効化メールが送信される" do
+        click_button submit
+        expect(activation_mail.to).to eq ["tom@ne.jp"]
+        expect(activation_mail.from).to eq ["noreply@example.com"]
+        expect(activation_mail.subject).to match "アカウント有効化"
       end
     end
 
@@ -71,6 +82,36 @@ describe "ユーザー機能", type: :system do
     end
   end
 
+  describe "アカウント有効化機能" do
+    context "正しいリンクからアクセスしたとき" do
+      before do
+        user.send_activation_email
+        visit edit_account_activation_url(user.activation_token, email: user.email)
+      end
+
+      it "アカウントを有効化する" do
+        within ".alert" do
+          expect(page).to have_content "アカウントを有効化しました"
+        end
+        expect(user.reload.activated).to eq true
+      end
+    end
+
+    context "無効なリンクからアクセスしたとき" do
+      before do
+        user.send_activation_email
+        visit edit_account_activation_url("invalid_token", email: user.email)
+      end
+
+      it "アカウントを有効化しない" do
+        within ".alert" do
+          expect(page).to have_content "このリンクは無効です"
+        end
+        expect(user.reload.activated).to eq false
+      end
+    end
+  end
+
   describe "プロフィール編集機能" do
     before do
       login_as user
@@ -100,6 +141,12 @@ describe "ユーザー機能", type: :system do
           end
           expect(user.reload.name).to eq new_name
           expect(user.reload.email).to eq new_email
+        end
+
+        it "アカウント有効化メールが送信される" do
+          expect(activation_mail.to).to eq [new_email]
+          expect(activation_mail.from).to eq ["noreply@example.com"]
+          expect(activation_mail.subject).to match "アカウント有効化"
         end
       end
 
@@ -200,6 +247,150 @@ describe "ユーザー機能", type: :system do
         click_link "削除", match: :first
         page.driver.browser.switch_to.alert.accept
         expect(page).not_to have_content user.name
+      end
+    end
+  end
+
+  describe "アカウント有効化メール再送信機能" do
+    before { visit new_account_activation_path }
+
+    context "メールアドレスが存在しないとき" do
+      before { fill_in "account_activation[email]", with: "dummy@example.com" }
+
+      it "メールは送信されない" do
+        expect { click_button "メールを送信する" }.not_to change { ActionMailer::Base.deliveries }
+        within ".alert" do
+          expect(page).to have_content "メールアドレスが間違っているかすでに有効化されています"
+        end
+      end
+    end
+
+    context "すでにアカウントが有効化されているとき" do
+      before { fill_in "account_activation[email]", with: activated_user.email }
+
+      it "メールは送信されない" do
+        expect { click_button "メールを送信する" }.not_to change { ActionMailer::Base.deliveries.count }
+        within ".alert" do
+          expect(page).to have_content "メールアドレスが間違っているかすでに有効化されています"
+        end
+      end
+    end
+
+    context "入力されたメールアドレスが正しいとき" do
+      before { fill_in "account_activation[email]", with: user.email }
+
+      it "メールが送信される" do
+        expect { click_button "メールを送信する" }.to change { ActionMailer::Base.deliveries.count }.by(1)
+        expect(activation_mail.to).to eq [user.email]
+        within ".alert" do
+          expect(page).to have_content "メールを送信しました"
+        end
+      end
+    end
+  end
+
+  describe "パスワード再設定メール送信機能" do
+    before { visit new_password_reset_path }
+
+    context "登録されていないメールアドレスを入力したとき" do
+      before { fill_in "password_reset[email]", with: "non-exist@example.com" }
+
+      it "メールは送信されない" do
+        expect { click_button "メールを送信する" }.not_to change { ActionMailer::Base.deliveries.count }
+        within ".alert" do
+          expect(page).to have_content "メールアドレスが間違っているかアカウントが有効化されていません"
+        end
+      end
+    end
+
+    context "アカウントが有効化されていないとき" do
+      before { fill_in "password_reset[email]", with: user.email }
+
+      it "メールは送信されない" do
+        expect { click_button "メールを送信する" }.not_to change { ActionMailer::Base.deliveries.count }
+        within ".alert" do
+          expect(page).to have_content "メールアドレスが間違っているかアカウントが有効化されていません"
+        end
+      end
+    end
+
+    context "有効化されたアカウントのメールアドレスを入力したとき" do
+      before { fill_in "password_reset[email]", with: activated_user.email }
+
+      it "メールが送信される" do
+        expect { click_button "メールを送信する" }.to change { ActionMailer::Base.deliveries.count }.by(1)
+        expect(password_reset_mail.to).to eq [activated_user.email]
+        within ".alert" do
+          expect(page).to have_content "メールを送信しました"
+        end
+      end
+    end
+  end
+
+  describe "パスワード再設定機能" do
+    let(:new_password) { "newpassword" }
+
+    before do
+      activated_user.create_reset_digest and activated_user.reload
+      activated_user.send_password_reset_email
+    end
+
+    context "リンクの期限が切れているとき" do
+      before do
+        activated_user.update!({ reset_sent_at: 3.hours.ago })
+        visit edit_password_reset_url(activated_user.reset_token, email: activated_user.email)
+      end
+
+      it "パスワード再設定ページにアクセスできない" do
+        within ".alert" do
+          expect(page).to have_content "リンクの有効期限が切れています"
+        end
+        expect(page).to have_current_path new_password_reset_path
+      end
+    end
+
+    context "リンクが正しくないとき" do
+      before do
+        visit edit_password_reset_url("invalid_token", email: activated_user.email)
+      end
+
+      it "パスワード再設定ページにアクセスできない" do
+        within ".alert" do
+          expect(page).to have_content "このリンクは無効です"
+        end
+        expect(page).to have_current_path root_path
+      end
+    end
+
+    context "新しいパスワードの入力が正しいとき" do
+      before do
+        visit edit_password_reset_url(activated_user.reset_token, email: activated_user.email)
+        fill_in "user[password]", with: new_password
+        fill_in "user[password_confirmation]", with: new_password
+        click_button "パスワードを変更する"
+      end
+
+      it "パスワードが変更される" do
+        within ".alert" do
+          expect(page).to have_content "パスワードを更新しました"
+        end
+        expect(activated_user.reload.authenticate(new_password)).to eq activated_user
+      end
+    end
+
+    context "新しいパスワードの入力が正しくないとき" do
+      before do
+        visit edit_password_reset_url(activated_user.reset_token, email: activated_user.email)
+        fill_in "user[password]", with: new_password
+        fill_in "user[password_confirmation]", with: "hogehoge"
+        click_button "パスワードを変更する"
+      end
+
+      it "パスワードは変更されない" do
+        within ".error-message" do
+          expect(page).to have_content "パスワードの入力が一致していません"
+        end
+        expect(activated_user.reload.authenticate(new_password)).to eq false
       end
     end
   end


### PR DESCRIPTION
close #128 

## 概要
- login_asメソッドの修正
  - capybara使ってなくてもログインできるようにする
    - その場合は第２引数に` no_capybara: true`を指定する
- `system/users_spec.rb`にパスワードリセットとアカウント有効化に関するテストを追加

## テスト内容
- RSpecがパスすることを確認
  - この時点でのカバレッジは87.91%

## 補足
- updateに関するテストを書く場合はrspec側でreloadしないと変更が反映されなくて期待通りの挙動にならないケースがあるから注意

## 参考URL
- [rspecでupdateのテストを通せない初心者が疑うべきこと](https://qiita.com/ry_2718/items/3ffdf7c24857fc5724c2)
- [rspecでcontrollerの処理をした時やmodelの処理時にメールが配信された事やメールの内容をテストしたい](https://qiita.com/zenpou/items/64f101cb39d8b2e3ff06)
- [Rails Tutorial 第２版](https://github.com/yasslab/sample_apps/tree/master/4_0_5)（この頃はテストがRSpec）
- [RSpecでcookies.signedを使う](https://qiita.com/ktrkmk/items/99de2e6ce7515ddfbdd2)