### PR TITLE
マイグレーションファイルを戻す

### DIFF
--- a/db/migrate/20190302165901_create_rules.rb
+++ b/db/migrate/20190302165901_create_rules.rb
@@ -1,0 +1,10 @@
+class CreateRules < ActiveRecord::Migration[5.2]	
+  def change	
+    create_table :rules do |t|	
+      t.string :content, null: false	
+      t.references :habit, foreign_key: true, null: false	
+
+      t.timestamps	
+    end	
+  end	
+end


### PR DESCRIPTION
close #133 

## 概要
- #73 で誤って消したマイグレーションファイルをgithubからコピペで復旧させる

## テスト内容
- `rails db:migrate:reset`がエラーなく実行できることを確認
- テストがパスすることを確認