### PR TITLE
READMEの更新とテキストの微調整

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,45 @@
-# README
+# MakeHabits
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+習慣づくりのための自分ルールを作成するアプリです。  
+質問に答えていくことで、挫折しにくい自分ルールを作成することができます。  
+新しい習慣づくりだけではなく、悪い習慣をやめるためにも使えます。
 
-Things you may want to cover:
+## デモ
 
-* Ruby version
+<https://make-habits.herokuapp.com>
 
-* System dependencies
+* デモ用アカウント
 
-* Configuration
+```md
+メールアドレス: test_user@example.com
+パスワード: password
+```
 
-* Database creation
+## 実装した主な機能
 
-* Database initialization
+* ログイン機能
+  * 認証まわりの勉強を兼ねてdevise等のgemを使わずに実装しました
+* Twitterログイン機能
+* メール送信機能
+  * アカウント有効化とパスワード再設定の時に使用
+* 管理ユーザー機能
+  * 管理ユーザーのみユーザー一覧へのアクセスと他のユーザーの削除が可能
+  * ユーザー一覧ページではページネーション機能を実装
+* 画像アップロード機能
+  * 本番環境ではS3を使用
+* DBテーブルのリレーション管理
+* 単一テーブル継承（STI）機能
+* ルール機能
+  * 作成, 一覧, 編集, 削除
+* ajaxを利用した非同期通信
+* html2canvasを利用した画像ダウンロード機能
+* rubocop
+* RSpecによる統合テスト,単体テスト
 
-* How to run the test suite
+## バージョン
 
-* Services (job queues, cache servers, search engines, etc.)
-
-* Deployment instructions
-
-* ...
+* ruby 2.5.1
+* rails 5.2.2
+* node 10.8.0
+* yarn 1.9.4
+* PostgreSQL 10.5

--- a/app/views/quits/new2.html.haml
+++ b/app/views/quits/new2.html.haml
@@ -5,7 +5,7 @@
     %p.lead
       その習慣をついやってしまうのはどのような状況ですか？
       %br
-      すぐに思いつかなかったら数日生活してみて、ついやってしまう状況を記録してみましょう
+      すぐに思いつかなかったら数日生活してみて、やってしまう状況を記録してみましょう
 
     = form_for(:quit, url: quits_new_3_path, method: :get) do |f|
       = f.hidden_field :title, value: @title


### PR DESCRIPTION
close #140 

## 概要
- ポートフォリオとして公開するためにREADMEを記述
- `quits/new/2`のテキストが大きめの画面だと１文字だけ改行されてしまうので修正
  - これは目立つからすぐ修正したけど、画面幅によっては見にくい改行になってる部分は多分他にもあるから修正すべき

## テスト内容
- vscodeのプレビュー機能でREADMEの表示を確認
- `quits/new/2`の１文字だけ改行されるのが改善されたことを確認