### PR TITLE
ルール作成フォームのフォントサイズのレスポンシブ対応

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -54,6 +54,11 @@ ul {
   opacity: .7;
 }
 
+.placeholder {
+  font-size: .8rem;
+  color: #555;
+}
+
 // header
 header {
   .navbar {
@@ -161,10 +166,6 @@ header {
   margin: 2rem auto;
   max-width: 400px;
   box-shadow: 0 2px 2px rgba(0, 0, 0, 0.3);
-}
-.placeholder {
-  font-size: .8rem;
-  color: #555;
 }
 .invite-text {
   display: inline-block;
@@ -389,6 +390,9 @@ header {
   }
   ::placeholder {
     color: rgba(134, 164, 164, 0.7);
+  }
+  .placeholder {
+    font-size: 1rem;
   }
   .hint-text {
     font-size: 1.2rem;
@@ -669,6 +673,11 @@ footer {
           font-size: 1.1rem;
         }
       }
+    }
+  }
+  .makes-new-wrapper, .quits-new-wrapper {
+    .placeholder {
+      font-size: .7rem;
     }
   }
 }

--- a/app/views/makes/new1.html.haml
+++ b/app/views/makes/new1.html.haml
@@ -9,6 +9,6 @@
       身につけたい習慣はなんですか？
 
     = form_for(:make, url: makes_new_2_path, method: :get) do |f|
-      = f.text_field :title, required: true, maxlength: 100, class: "form-control mt-5", placeholder: "ex) 筋トレ"
+      = f.text_field :title, required: true, maxlength: 100, class: "form-control mt-5 placeholder", placeholder: "ex) 筋トレ"
 
       = f.submit "次へ", class: "btn btn-info mt-5"

--- a/app/views/makes/new3.html.haml
+++ b/app/views/makes/new3.html.haml
@@ -9,7 +9,7 @@
 
     = form_for(:make, url: makes_new_4_path, method: :get) do |f|
       = f.hidden_field :title, value: @title
-      = f.text_field :norm, required: true, maxlength: 150, class: "form-control mt-5", placeholder: "ex) １回スクワットをする"
+      = f.text_field :norm, required: true, maxlength: 150, class: "form-control mt-5 placeholder", placeholder: "ex) １回スクワットをする"
 
       = f.submit "次へ", class: "btn btn-info mt-5"
 

--- a/app/views/makes/new5.html.haml
+++ b/app/views/makes/new5.html.haml
@@ -11,7 +11,7 @@
 
     = form_for(:make, url: makes_new_6_path, method: :get) do |f|
       = f.hidden_field :title, value: @title
-      = f.text_area :rule1, required: true, maxlength: 255, class: "form-control mt-5", value: "#{@norm}",
+      = f.text_area :rule1, required: true, maxlength: 255, class: "form-control mt-5 placeholder", value: "#{@norm}",
                             placeholder: "「すでにある習慣を実行したらノルマを行う」という形で自分ルールを作成してください"
 
       = f.submit "次へ", class: "btn btn-info mt-5"

--- a/app/views/makes/new7.html.haml
+++ b/app/views/makes/new7.html.haml
@@ -11,6 +11,6 @@
     = form_for(:make, url: makes_new_8_path, method: :get) do |f|
       = f.hidden_field :title, value: @title
       = f.hidden_field :rule1, value: @rule1
-      = f.text_field :situation, required: true, maxlength: 150, class: "form-control mt-5", placeholder: "挫折しそうになる状況を入力してください"
+      = f.text_field :situation, required: true, maxlength: 150, class: "form-control mt-5 placeholder", placeholder: "挫折しそうになる状況を入力してください"
 
       = f.submit "次へ", class: "btn btn-info mt-5"

--- a/app/views/makes/new9.html.haml
+++ b/app/views/makes/new9.html.haml
@@ -11,7 +11,7 @@
     = form_for(:make, url: makes_path) do |f|
       = f.hidden_field :title, value: @title
       = f.hidden_field :rule1, value: @rule1
-      = f.text_area :rule2, required: true, maxlength: 255, class: "form-control mt-5", value: "#{@situation}",
+      = f.text_area :rule2, required: true, maxlength: 255, class: "form-control mt-5 placeholder", value: "#{@situation}",
                             placeholder: "「挫折しそうな状況になったら対策を行う」という形で自分ルールを作成してください"
 
       = f.submit "完成！", class: "btn btn-info mt-5"

--- a/app/views/quits/new1.html.haml
+++ b/app/views/quits/new1.html.haml
@@ -9,6 +9,6 @@
       やめたい習慣はなんですか？
 
     = form_for(:quit, url: quits_new_2_path, method: :get) do |f|
-      = f.text_field :title, required: true, maxlength: 255, class: "form-control mt-5", placeholder: "ex）ついYouTubeを見てしまう"
+      = f.text_field :title, required: true, maxlength: 255, class: "form-control mt-5 placeholder", placeholder: "ex）ついYouTubeを見てしまう"
 
       = f.submit "次へ", class: "btn btn-info mt-5"

--- a/app/views/quits/new3.html.haml
+++ b/app/views/quits/new3.html.haml
@@ -8,6 +8,7 @@
 
     = form_for(:quit, url: quits_new_4_path, method: :get) do |f|
       = f.hidden_field :title, value: @title
-      = f.text_field :situation, required: true, maxlength: 150, class: "form-control mt-5", placeholder: "ex）自分の部屋で暇になったとき"
+      = f.text_field :situation, required: true, maxlength: 150, class: "form-control mt-5 placeholder",
+                                  placeholder: "ex）自分の部屋で暇になったとき"
 
       = f.submit "次へ", class: "btn btn-info mt-5"

--- a/app/views/quits/new5.html.haml
+++ b/app/views/quits/new5.html.haml
@@ -10,7 +10,7 @@
 
     = form_for(:quit, url: quits_new_6_path, method: :get) do |f|
       = f.hidden_field :title, value: @title
-      = f.text_area :rule1, required: true, maxlength: 255, class: "form-control mt-5", value: "#{@situation}",
+      = f.text_area :rule1, required: true, maxlength: 255, class: "form-control mt-5 placeholder", value: "#{@situation}",
                             placeholder: "「やってしまう状況になったら代わりの行動をする」という形で自分ルールを作成してください"
 
       = f.submit "次へ", class: "btn btn-info mt-5"

--- a/app/views/quits/new7.html.haml
+++ b/app/views/quits/new7.html.haml
@@ -11,7 +11,8 @@
     = form_for(:quit, url: quits_path) do |f|
       = f.hidden_field :title, value: @title
       = f.hidden_field :rule1, value: @rule1
-      = f.text_area :rule2, required: true, maxlength: 255, class: "form-control mt-5", placeholder: "２つ目の自分ルールを入力してください"
+      = f.text_area :rule2, required: true, maxlength: 255, class: "form-control mt-5 placeholder",
+                            placeholder: "やめたい習慣を簡単にはできないようにする自分ルールを作成してください"
 
       = f.submit "完成！", class: "btn btn-info mt-5"
 


### PR DESCRIPTION
close #146 

## 概要
- ルール作成フォームのplaceholderとvalueのフォントサイズがレスポンシブ対応になってなかったので修正

## テスト内容
- トピックブランチをデプロイして実機での表示を確認

## 残課題
- iOSでは16px以下を指定したフォームにフォーカスすると画面が勝手にズームされる仕様らしく、それが結構嫌なのでなんらかの対策をする