### PR TITLE
デモアカウント情報とルールの制限個数の修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ```md
 メールアドレス: test_user@example.com
-パスワード: password
+パスワード: test1234
 ```
 
 ## 実装した主な機能

--- a/app/controllers/makes_controller.rb
+++ b/app/controllers/makes_controller.rb
@@ -69,8 +69,8 @@ class MakesController < HabitsController
     end
 
     def check_number_of_makes
-      if current_user.makes.count >= 15
-        flash[:warning] = "同時に作成できるルールは15個ずつまでです"
+      if current_user.makes.count >= 50
+        flash[:warning] = "同時に作成できるルールは50個ずつまでです"
         redirect_to current_user
       end
     end

--- a/app/controllers/quits_controller.rb
+++ b/app/controllers/quits_controller.rb
@@ -61,8 +61,8 @@ class QuitsController < HabitsController
     end
 
     def check_number_of_quits
-      if current_user.quits.count >= 15
-        flash[:warning] = "同時に作成できるルールは15個ずつまでです"
+      if current_user.quits.count >= 50
+        flash[:warning] = "同時に作成できるルールは50個ずつまでです"
         redirect_to current_user
       end
     end

--- a/app/models/make.rb
+++ b/app/models/make.rb
@@ -4,8 +4,8 @@ class Make < Habit
   private
 
     def check_number_of_makes
-      if user && user.makes.count >= 15
-        errors.add(:base, "同時に作成できるルールは15個までです")
+      if user && user.makes.count >= 50
+        errors.add(:base, "同時に作成できるルールは50個までです")
       end
     end
 end

--- a/app/models/quit.rb
+++ b/app/models/quit.rb
@@ -4,8 +4,8 @@ class Quit < Habit
   private
 
     def check_number_of_quits
-      if user && user.quits.count >= 15
-        errors.add(:base, "同時に作成できるルールは15個までです")
+      if user && user.quits.count >= 50
+        errors.add(:base, "同時に作成できるルールは50個までです")
       end
     end
 end

--- a/app/views/sessions/new.html.haml
+++ b/app/views/sessions/new.html.haml
@@ -6,7 +6,7 @@
     .font-weight-bold
       test_user@example.com
       %br
-      password
+      test1234
   .card.card-container
     = image_tag "logo.png", size: "200x55", class: "mx-auto"
     = link_to  '/auth/twitter', class: "btn btn-twitter mt-4" do

--- a/db/seeds/development.rb
+++ b/db/seeds/development.rb
@@ -12,6 +12,11 @@ User.create!(
   password: "foobar",
 )
 
+User.create!(
+  name: "test_user",
+  email: "test_user@example.com",
+  password: "test1234",
+)
 50.times do |i|
   User.create(
     name: "hoge",
@@ -20,7 +25,7 @@ User.create!(
   )
 end
 
-15.times do |i|
+50.times do |i|
   user.makes.create(
     title: "make#{i}",
     rule1: "hoge",
@@ -28,7 +33,7 @@ end
   )
 end
 
-15.times do |i|
+50.times do |i|
   user.quits.create(
     title: "quit#{i}",
     rule1: "hoge",

--- a/db/seeds/production.rb
+++ b/db/seeds/production.rb
@@ -5,3 +5,10 @@ User.create!(
   admin: true,
   activated: true,
 )
+
+User.create!(
+  name: "test_user",
+  email: "test_user@example.com",
+  password: "test1234",
+  activated: true,
+)

--- a/spec/models/make_spec.rb
+++ b/spec/models/make_spec.rb
@@ -75,10 +75,10 @@ RSpec.describe Make, type: :model do
       end
     end
 
-    context "16個以上作成しようとした場合" do
+    context "51個以上作成しようとした場合" do
       let(:user) { FactoryBot.create(:user, email: "test@example.com") }
       before do
-        15.times do
+        50.times do
           user.makes.create!(
             title: "hoge",
             rule1: "foo",

--- a/spec/models/quit_spec.rb
+++ b/spec/models/quit_spec.rb
@@ -75,10 +75,10 @@ RSpec.describe Quit, type: :model do
       end
     end
 
-    context "16個以上作成しようとした場合" do
+    context "51個以上作成しようとした場合" do
       let(:user) { FactoryBot.create(:user, email: "test@example.com") }
       before do
-        15.times do
+        50.times do
           user.quits.create!(
             title: "hoge",
             rule1: "foo",

--- a/spec/system/makes_spec.rb
+++ b/spec/system/makes_spec.rb
@@ -91,10 +91,10 @@ describe "自分ルール機能(make)", type: :system do
       end
     end
 
-    context "すでに15個のルールがあるとき" do
+    context "すでに50個のルールがあるとき" do
       before do
-        # 上記のテストで１つ作成されているためここでは14個
-        14.times do
+        # 上記のテストで１つ作成されているためここでは49個
+        49.times do
           login_user.makes.create!(
             title: "hoge",
             rule1: "foo",
@@ -106,7 +106,7 @@ describe "自分ルール機能(make)", type: :system do
 
       it "マイページにリダイレクトされる" do
         within ".alert" do
-          expect(page).to have_content "同時に作成できるルールは15個ずつまでです"
+          expect(page).to have_content "同時に作成できるルールは50個ずつまでです"
         end
         expect(page).to have_current_path user_path(login_user)
       end

--- a/spec/system/quits_spec.rb
+++ b/spec/system/quits_spec.rb
@@ -86,10 +86,10 @@ describe "自分ルール機能(quit)", type: :system do
       end
     end
 
-    context "すでに15個のルールがあるとき" do
+    context "すでに50個のルールがあるとき" do
       before do
-        # 上記のテストで１つ作成されているためここでは14個
-        14.times do
+        # 上記のテストで１つ作成されているためここでは49個
+        49.times do
           login_user.quits.create!(
             title: "hoge",
             rule1: "foo",
@@ -101,7 +101,7 @@ describe "自分ルール機能(quit)", type: :system do
 
       it "マイページにリダイレクトされる" do
         within ".alert" do
-          expect(page).to have_content "同時に作成できるルールは15個ずつまでです"
+          expect(page).to have_content "同時に作成できるルールは50個ずつまでです"
         end
         expect(page).to have_current_path user_path(login_user)
       end


### PR DESCRIPTION
close #151 

## 概要
- ルールの制限個数を増やす
- デモアカウントのパスワードを変更
- seedファイルの変更

## テスト内容
- RSpecがパスすることを確認
- 変更後のアカウント情報でログインできることを確認