### PR TITLE
お試しログインボタンの設置

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -167,9 +167,6 @@ header {
   max-width: 400px;
   box-shadow: 0 2px 2px rgba(0, 0, 0, 0.3);
 }
-.demo-account {
-  background-color: #e5f5f7;
-}
 .invite-text {
   display: block;
   margin-top: .8rem;

--- a/app/views/sessions/new.html.haml
+++ b/app/views/sessions/new.html.haml
@@ -1,12 +1,11 @@
 .container
-  .card.card-container.p-3.demo-account
-    以下のアドレスとパスワードでログイン可能です
-    %br
-    %br
-    .font-weight-bold
-      test_user@example.com
-      %br
-      test1234
+  .card.card-container
+    %p
+      テストユーザーとしてログインできます
+    = form_for(:session, url: login_path) do |f|
+      = f.hidden_field :email, value: "test_user@example.com", id: "hiddden_email"
+      = f.hidden_field :password, value: "test1234", id: "hidden_password"
+      = f.submit "お試しログイン", class: "btn btn-info btn-block demo-btn mt-3 mb-2 mx-auto"
   .card.card-container
     = image_tag "logo.png", size: "200x55", class: "mx-auto"
     = link_to  '/auth/twitter', class: "btn btn-twitter mt-4" do

--- a/app/views/users/new.html.haml
+++ b/app/views/users/new.html.haml
@@ -1,5 +1,12 @@
 .container
   .card.card-container
+    %p
+      テストユーザーとしてログインできます
+    = form_for(:session, url: login_path) do |f|
+      = f.hidden_field :email, value: "test_user@example.com"
+      = f.hidden_field :password, value: "test1234"
+      = f.submit "お試しログイン", class: "btn btn-info btn-block demo-btn mt-3 mb-2 mx-auto"
+  .card.card-container
     = image_tag "logo.png", size: "200x55", class: "mx-auto"
     = link_to  '/auth/twitter', class: "btn btn-twitter mt-4", id: "twitter-signup" do
       = icon("fab", "twitter", class: "mr-1")


### PR DESCRIPTION
close #153 

## 概要
- 新規登録ページとログインページにワンクリックでテストアカウントにログインできるボタンを設置
  - 中身をみてもらえる可能性を高めるため

## テスト内容
- どちらのページのボタンからでもテストユーザーとしてログインできることを確認

## 補足
- テストユーザーのアカウント情報が変更されたらログインできなくなってしまうので、テストユーザーのemailとpasswordを変更できないようにする必要がある