### PR TITLE
テストユーザーでアバター画像以外のユーザー編集を禁止する

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,6 +5,7 @@ class UsersController < ApplicationController # rubocop:disable Metrics/ClassLen
   before_action :check_correct_user, only: [:show, :edit, :update_profile, :update_password, :delete]
   before_action :check_admin, only: [:index]
   before_action :check_destroy, only: [:destroy]
+  before_action :forbid_test_user, only: [:update_profile, :update_password, :destroy]
 
   def index
     @users = User.order(id: :asc).page(params[:page])
@@ -72,6 +73,17 @@ class UsersController < ApplicationController # rubocop:disable Metrics/ClassLen
     end
   end
 
+  # デモアカウント用
+  def update_avatar
+    @user = User.find(params[:id])
+    if @user.update(params.require(:user).permit(:avatar))
+      flash[:success] = "プロフィール画像を更新しました"
+      redirect_to edit_user_path(@user)
+    else
+      render :edit
+    end
+  end
+
   def show
     @user = User.find(params[:id])
   end
@@ -120,5 +132,14 @@ class UsersController < ApplicationController # rubocop:disable Metrics/ClassLen
     def check_destroy
       @user = User.find(params[:id])
       redirect_to(current_user) unless current_user.admin? || @user == current_user
+    end
+
+    # デモアカウント用
+    def forbid_test_user
+      user = User.find(params[:id])
+      if user.email == "test_user@example.com"
+        redirect_to edit_user_path(user)
+        flash[:warning] = "デモ用アカウントはプロフィール画像のみ編集できます"
+      end
     end
 end

--- a/app/views/users/_edit_form_for_test_user.html.haml
+++ b/app/views/users/_edit_form_for_test_user.html.haml
@@ -1,0 +1,40 @@
+%p.mb-4
+  デモ用アカウントではプロフィール画像のみ編集できます
+%ul.nav.nav-tabs.nav-justified.text-center
+  %li.active.col-6
+    .show.active.select-edit-tab.pb-2{ "data-target" => "#profile-edit", "data-toggle" => "tab"} プロフィール
+  %li.col-6
+    .select-edit-tab.pb-2{ "data-target" => "#password-edit", "data-toggle" => "tab"} パスワード
+.tab-content.tabs-profile-edit.col-12
+  #profile-edit.tab-pane.fade.active.show.in
+    = image_tag "", class: "d-none", id: "avatar-img-prev"
+    = image_tag current_user.avatar.url, class: "avatar-present-img"
+    = form_for(user, url: update_avatar_path(params[:id])) do |f|
+      .text-center
+        = f.label :avatar, "プロフィール画像を選択", class: "file-upload-label"
+      = f.file_field :avatar, accept: "image/jpeg,image/gif,image/png", class: "d-none"
+
+      = render "shared/error_messages", object: f.object
+
+      = f.label :name, class: "form-label mt-4"
+      = f.text_field :name, required: true, maxlength: 50, class: "form-control placeholder mb-3",
+                            placeholder: "ユーザー名", readonly: true
+
+      = f.label :email, class: "form-label"
+      = f.email_field :email, required: true, maxlength: 255, class: "form-control placeholder mb-4",
+                              placeholder: "メールアドレス", readonly: true
+
+      = f.submit "プロフィール画像を更新する", class: "btn btn-info btn-block btn-update mt-4"
+  #password-edit.tab-pane.fade.col-12
+    = form_for(user, url: update_password_path(params[:id]), html: {id: "user_edit_2"}) do |f|
+      = render "shared/error_messages", object: f.object
+      = f.password_field :current_password, required: true, class: "form-control placeholder mt-5 mb-4",
+                                            placeholder: "現在のパスワード", readonly: true
+
+      = f.password_field :password, required: true, maxlength: 50, class: "form-control placeholder mb-4",
+                                    placeholder: "新しいパスワード（６文字以上）", readonly: true
+
+      = f.password_field :password_confirmation, required: true, maxlength: 50, class: "form-control placeholder",
+                                                 placeholder: "新しいパスワード（確認）", readonly: true
+
+      = f.submit "パスワードを更新する", class: "btn btn-info btn-block btn-update mt-4", disabled: true

--- a/app/views/users/delete.html.haml
+++ b/app/views/users/delete.html.haml
@@ -6,4 +6,9 @@
           アカウントを削除すると、これまでに作成されたデータは全て削除されます。
         %li
           削除されたデータを復旧することはできません。
-    = link_to "アカウントを削除する", user_path(@user), method: :delete, data: { confirm: "本当に削除しますか？" }, class: "btn btn-danger"
+    - if @user.email == "test_user@example.com" # デモアカウント用
+      %button.btn.btn-danger{href: "#", disabled: true} アカウントを削除する
+      %span.mt-2
+        デモアカウントは削除できません
+    - else
+      = link_to "アカウントを削除する", user_path(@user), method: :delete, data: { confirm: "本当に削除しますか？" }, class: "btn btn-danger"

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -2,6 +2,8 @@
   .card.card-container
     - if @user.provider == "twitter"
       = render "edit_form_for_twitter", user: @user
+    - elsif @user.email == "test_user@example.com" # デモアカウント用
+      = render "edit_form_for_test_user", user: @user
     - else
       = render "edit_form", user: @user
   = link_to "アカウントを削除する場合はこちらから", delete_page_path(@user), class: "invite-text invite-delete text-center mb-5"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
   get "/admin/users", to: "users#index"
   patch "/users/:id/profile", to: "users#update_profile", as: "update_profile"
   patch "/users/:id/password", to: "users#update_password", as: "update_password"
+  patch "/users/:id/avatar", to: "users#update_avatar", as: "update_avatar" # デモアカウント用
   get "/users/:id/delete", to: "users#delete", as: "delete_page"
   resources :users, except: [:index, :update]
 

--- a/db/seeds/production.rb
+++ b/db/seeds/production.rb
@@ -10,5 +10,4 @@ User.create!(
   name: "test_user",
   email: "test_user@example.com",
   password: "test1234",
-  activated: true,
 )

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,9 +1,15 @@
 FactoryBot.define do
   factory :user do
-    name { "テストユーザー" }
+    name { "一般ユーザー" }
     email { "test1@example.com" }
     password { "password" }
     avatar { Rack::Test::UploadedFile.new(File.join(Rails.root, "spec/fixtures/icon.png")) }
+  end
+
+  factory :test_user, class: User do
+    name { "デモ用ユーザー" }
+    email { "test_user@example.com" }
+    password { "password" }
   end
 
   factory :admin_user, class: User do

--- a/spec/system/test_users_spec.rb
+++ b/spec/system/test_users_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+describe "テストユーザー機能", type: :system do
+  let(:test_user) { FactoryBot.create(:test_user) }
+  before { login_as test_user }
+
+  describe "プロフィール編集機能" do
+    before { visit edit_user_path(test_user) }
+
+    describe "アバター画像編集" do
+      before do
+        attach_file "user[avatar]", "#{Rails.root}/spec/fixtures/icon.png", make_visible: true
+        click_button "プロフィール画像を更新する"
+      end
+
+      it "アバター画像は更新できる" do
+        within ".alert" do
+          expect(page).to have_content "プロフィール画像を更新しました"
+        end
+      end
+    end
+
+    describe "ユーザー名/メールアドレス編集" do
+      it "ユーザー名とメールアドレスのフォームの値は編集できない" do
+        expect(page).to have_field "ユーザー名", with: test_user.name, readonly: true
+        expect(page).to have_field "メールアドレス", with: test_user.email, readonly: true
+      end
+    end
+
+    describe "パスワード編集" do
+      before do
+        page.execute_script('$("#profile-edit").removeClass("show active")')
+        page.execute_script('$("#password-edit").addClass("show active")')
+      end
+
+      it "フォームの編集と更新ボタンのクリックができない" do
+        expect(page).to have_field "user[current_password]", placeholder: "現在のパスワード", readonly: true
+        expect(page).to have_field "user[password]", placeholder: "新しいパスワード（６文字以上）", readonly: true
+        expect(page).to have_field "user[password_confirmation]", placeholder: "新しいパスワード（確認）", readonly: true
+        expect(page).to have_button "パスワードを更新する", disabled: true
+      end
+    end
+  end
+
+  describe "アカウント削除機能" do
+    before { visit delete_page_path(test_user) }
+
+    it "削除ボタンをクリックできない" do
+      expect(page).to have_button "アカウントを削除する", disabled: true
+    end
+  end
+end


### PR DESCRIPTION
close #154 

## 概要
- テストユーザーがプロフィール画像以外のユーザー情報を変更できないようにする
  - 変えられたら「お試しログイン」ボタンでログインできなくなってしまうため
- テストユーザー用のsystem specを記述

## テスト内容
- テストユーザーとしてログインしたとき
  - アバター画像を編集できることを確認
  - ユーザー名とメールアドレスフォームが編集できないことを確認
  - パスワードフォームが編集できないことを確認
- RSpecが通ることを確認

## 補足
- テストアバター用の処理は必要なくなった時に消しやすいようになるべく切り出して記述

## 参考URL
- [使えるRSpec入門・その4「どんなブラウザ操作も自由自在！逆引きCapybara大辞典」](https://qiita.com/jnchito/items/607f956263c38a5fec24)
- [Capybara | have_selector で disabled なフィールドを検証する](https://qiita.com/jnchito/items/607f956263c38a5fec24)