### PR TITLE
プロフィール画像のサイズが５MB以上だった時の処理の修正

### DIFF
--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -1,10 +1,11 @@
 document.addEventListener('turbolinks:load', function() {
   $('#user_avatar').bind('change', function() {
     // プロフィール画像サイズのバリデーション
-    if(this.files && this.files[0]) {
+    if (this.files && this.files[0]) {
       let size_in_megabytes = this.files[0].size/1024/1024;
       if (size_in_megabytes > 5) {
         alert('画像は５MB以下のものにしてください');
+        this.value = null;
       }
     }
 
@@ -12,7 +13,7 @@ document.addEventListener('turbolinks:load', function() {
     function readURL(input) {
       if (input.files && input.files[0]) {
         let reader = new FileReader();
-  
+
         reader.onload = function (e) {
           $('#avatar-img-prev').attr('src', e.target.result);
         };

--- a/config/locales/carrierwave_ja.yml
+++ b/config/locales/carrierwave_ja.yml
@@ -1,0 +1,14 @@
+ja:
+  errors:
+    messages:
+      carrierwave_processing_error: 処理できませんでした
+      carrierwave_integrity_error: は許可されていないファイルタイプです
+      carrierwave_download_error: はダウンロードできません
+      extension_whitelist_error: "%{extension}ファイルのアップロードは許可されていません。アップロードできるファイルタイプ: %{allowed_types}"
+      extension_blacklist_error: "%{extension}ファイルのアップロードは許可されていません。アップロードできないファイルタイプ: %{prohibited_types}"
+      content_type_whitelist_error: "%{content_type}ファイルのアップロードは許可されていません"
+      content_type_blacklist_error: "%{content_type}ファイルのアップロードは許可されていません"
+      rmagick_processing_error: "rmagickがファイルを処理できませんでした。画像を確認してください。エラーメッセージ: %{e}"
+      mini_magick_processing_error: "MiniMagickがファイルを処理できませんでした。画像を確認してください。エラーメッセージ: %{e}"
+      min_size_error: "ファイルを%{min_size}バイト以上のサイズにしてください"
+      max_size_error: "は%{max_size}バイト以下にしてください"


### PR DESCRIPTION
close #156 

## 概要
- carrierwaveのバリデーションに引っかかった時用の翻訳ファイルの作成
- セットされたファイルが５MB以上だった時にファイルを空にする処理を追加

## テスト内容
- ５MB以上の画像ファイルを送信した時に日本語に翻訳されたエラーメッセージが表示されることを確認
  - ファイルを空にする処理を外して動作確認をおこなった
- ５MBのファイルをセットするとフォームが空になることを確認
- RSpecがパスすることを確認

## 参考URL
- [carrierwaveのファイルのサイズ制限とエラーメッセージの日本語化。](http://arthurxxx.hatenablog.com/entry/2018/03/08/222925)