### PR TITLE
画像が勝手に回転することへの対処

### DIFF
--- a/app/uploaders/avatar_uploader.rb
+++ b/app/uploaders/avatar_uploader.rb
@@ -3,6 +3,7 @@ class AvatarUploader < CarrierWave::Uploader::Base
   # include CarrierWave::RMagick
   include CarrierWave::MiniMagick
   process resize_to_fill: [200, 200]
+  process :fix_exif_rotation_and_strip_exif
 
   # Choose what kind of storage to use for this uploader:
 
@@ -10,6 +11,16 @@ class AvatarUploader < CarrierWave::Uploader::Base
     storage :fog
   else
     storage :file
+  end
+
+  # exif情報を修正して保存
+  def fix_exif_rotation_and_strip_exif
+    manipulate! do |img|
+      img.auto_orient
+      img.strip # rubocop:disable Lint/Void
+      img = yield(img) if block_given?
+      img
+    end
   end
 
   # Override the directory where uploaded files will be stored.

--- a/app/uploaders/avatar_uploader.rb
+++ b/app/uploaders/avatar_uploader.rb
@@ -2,7 +2,7 @@ class AvatarUploader < CarrierWave::Uploader::Base
   # Include RMagick or MiniMagick support:
   # include CarrierWave::RMagick
   include CarrierWave::MiniMagick
-  process resize_to_fill: [200, 200]
+  # process resize_to_fill: [200, 200]
   process :fix_exif_rotation_and_strip_exif
 
   # Choose what kind of storage to use for this uploader:


### PR DESCRIPTION
close #163 

## 修正内容
- carrierwave側の設定で保存する際にexifのrotateを修正した
- プレビュー表示と保存された時の表示が変化しないようにアップローダーの`resize_to_fill`をコメントアウト

## テスト内容
- プレビューで横向きに表示されてしまう画像も保存すると正しい向きになることを確認
- RSpecがパスすることを確認

## 残課題
- プレビュー表示は修正できていない(#164 で対応)

## 参考URL
- [carriewaveでExifの回転情報(rotation)をよしなに修正した後 Exif情報を除去する](https://qiita.com/goyachanpuru/items/5939dbc1637e5ea4be74)