### PR TITLE
ルール一覧を色分けして種類をわかりやすくする

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -294,10 +294,10 @@ header {
     line-height: 3rem;
     letter-spacing: .15rem;
   }
-  .btn-info {
-    border-bottom: solid 4px #0f6674;
+  .btn-success {
+    border-bottom: solid 4px #1e7e34;
     &:hover {
-      background-color: #17a2b8;
+      background-color: #28a745;
     }
     &:active {
       -webkit-transform: translateY(4px);
@@ -457,7 +457,7 @@ header {
 }
 .quits-show-wrapper {
   .title {
-    background-color: #ffffd7;
+    background-color: #fff4d2;
   }
 }
 
@@ -481,6 +481,22 @@ header {
           color: white;
         }
       }
+      .nav-make {
+        color: #00b300;
+        border: 1px solid #00b300;
+        &.active {
+          background-color: #00b300;
+          color: white;
+        }
+      }
+      .nav-quit {
+        color: #ffc017;
+        border: 1px solid #ffc017;
+        &.active {
+          background-color: #ffc017;
+          color: black;
+        }
+      }
     }
   }
   .jumbotron {
@@ -496,9 +512,6 @@ header {
     .habit {
       padding: 1.5rem .5rem;
       position: relative;
-      &:hover {
-        background-color: #dedede;
-      }
       a {
         position:absolute;
         top:0;
@@ -515,6 +528,18 @@ header {
         display: inline-block;
         width: 10%;
         font-size: 1.2rem;
+      }
+    }
+    .make {
+      background:linear-gradient(90deg,#e5ffe5 0%,#e5ffe5 2%,#f7f7f7 2%,#f7f7f7 100%);
+      &:hover {
+        background:linear-gradient(90deg,#ccffcc 0%,#ccffcc 2%,#ebebeb 2%,#ebebeb 100%);
+      }
+    }
+    .quit {
+      background:linear-gradient(90deg,#ffeeb9 0%,#ffeeb9 2%,#f7f7f7 2%,#f7f7f7 100%);
+      &:hover {
+        background:linear-gradient(90deg,#ffe89f 0%,#ffe89f 2%,#ebebeb 2%,#ebebeb 100%);
       }
     }
   }
@@ -656,6 +681,7 @@ footer {
     }
     .nav-tabs {
       .nav-item {
+        width : 32%;
         a {
           font-size: .9rem;
         }
@@ -736,12 +762,11 @@ footer {
     }
     .nav-tabs {
       .nav-item {
-        width : 30%;
         a {
           font-size: .7rem;
         }
         .nav-link {
-          padding: .5rem;
+          padding: .5rem 0;
         }
       }
     }

--- a/app/views/habits/select.html.haml
+++ b/app/views/habits/select.html.haml
@@ -3,5 +3,5 @@
     %p.lead
       下記のどちらかを選んでください
     .mt-5
-      = link_to "身につけたい習慣がある", makes_new_1_path, class: "btn btn-info col-10 col-offset-1 col-md-4 mr-3"
+      = link_to "身につけたい習慣がある", makes_new_1_path, class: "btn btn-success col-10 col-offset-1 col-md-4 mr-3"
       = link_to "やめたい習慣がある", quits_new_1_path, class: "btn btn-warning col-10 col-offset-1 col-md-4 ml-3"

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -5,9 +5,9 @@
     %li.nav-item
       %a.nav-link.active{"href" => "#tab1", "data-toggle" => "tab"} すべて
     %li.nav-item
-      %a.nav-link{"href" => "#tab2", "data-toggle" => "tab"} 身につけたい
+      %a.nav-link.nav-make{"href" => "#tab2", "data-toggle" => "tab"} 身につけたい習慣
     %li.nav-item
-      %a.nav-link{"href" => "#tab3", "data-toggle" => "tab"} やめたい
+      %a.nav-link.nav-quit{"href" => "#tab3", "data-toggle" => "tab"} やめたい習慣
   .jumbotron.mt-5.mx-auto.p-0
     .tab-content
       #tab1.tab-pane.active
@@ -19,8 +19,8 @@
             = link_to "こちら", habits_select_path
             から
         - else
-          - @user.habits.order(created_at: :desc).each do|habit|
-            .habit.d-flex.justify-content-around.align-items-center.border-bottom
+          - @user.habits.order(created_at: :desc).each do |habit|
+            .habit.d-flex.justify-content-around.align-items-center.border-bottom{ class: "#{habit.type == 'Make' ? 'make' : 'quit'}" }
               = link_to "", habit.type == "Make" ? make_path(habit.hashid) : quit_path(habit.hashid)
               %span.title
                 = habit.title
@@ -36,7 +36,7 @@
             から
         - else
           - @user.makes.order(created_at: :desc).each do|make|
-            .habit.d-flex.justify-content-around.align-items-center.border-bottom
+            .habit.make.d-flex.justify-content-around.align-items-center.border-bottom
               = link_to "", make
               %span.title
                 = make.title
@@ -52,7 +52,7 @@
             から
         - else
           - @user.quits.order(created_at: :desc).each do|quit|
-            .habit.d-flex.justify-content-around.align-items-center.border-bottom
+            .habit.quit.d-flex.justify-content-around.align-items-center.border-bottom
               = link_to "", quit
               %span.title
                 = quit.title


### PR DESCRIPTION
close #160 

## 概要
- タブの文字を`身につけたい習慣`, `やめたい習慣`に変更
- 小さいデバイスの時のタブのwidthとpaddingを調整（タブ内で改行しないように）
- タブを色分け
- 一覧もtypeによって色分けして表示

## テスト内容
- chromeの検証ツールで表示を確認
- RSpecがパスすることを確認