### PR TITLE
ルール一覧ページに新規作成ボタンを追加

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -543,6 +543,27 @@ header {
       }
     }
   }
+  .fixed-rule-make-btn {
+    color: white;
+    position: fixed;
+    bottom: 15px;
+    right: 15px;
+    height: 110px;
+    width: 110px;
+    border-radius: 50%;
+    background: #17a2b8;
+    text-align: center;
+    z-index: 100;
+    &:hover {
+      text-decoration: none;
+    }
+    & div {
+      margin: 12px 0 1px 0;
+    }
+    & i {
+      font-size: 40px;
+    }
+  }
 }
 
 // footer
@@ -663,7 +684,7 @@ footer {
     .lead {
       font-size: 1rem;
     }
-    .btn-info {
+    .btn-success {
       margin: 0!important;
     }
     .btn-warning {
@@ -698,6 +719,16 @@ footer {
         .number {
           font-size: 1.1rem;
         }
+      }
+    }
+    .fixed-rule-make-btn {
+      height: 95px;
+      width: 95px;
+      & div {
+        margin: 10px 0 1px 0;
+      }
+      & i {
+        font-size: 35px;
       }
     }
   }
@@ -790,6 +821,18 @@ footer {
         .number {
           font-size: 1rem;
         }
+      }
+    }
+    .fixed-rule-make-btn {
+      bottom: -15px;
+      right: -15px;
+      height: 80px;
+      width: 80px;
+      & div {
+        margin: 12px 0 1px 0;
+      }
+      & i {
+        font-size: 22px;
       }
     }
   }

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -58,3 +58,6 @@
                 = quit.title
               %span.number
                 = "#{quit.progress}%"
+  = link_to habits_select_path , class: "fixed-rule-make-btn" do
+    %div 作成
+    %i.fas.fa-plus


### PR DESCRIPTION
## 概要
- ヘッダーだけではわかりにくいのでルール一覧ページの右下に新規作成ボタンの追加
  - 常に固定で表示されてるよく見るやつ
- habits/selectのスマホ表示のボタン表示が崩れてたので修正（色変えたときに修正し忘れてた）

## テスト内容
- chromeの検証ツールで表示を確認
- RSpecがパスすることを確認

## 参考URL
- [link_to メソッド+ icon のhaml化 - haml化メモ](https://qiita.com/mitsuihinsuke/items/6adb56664d6e03fd24b4)