### PR TITLE
ヘッダーのユーザー名とマイページのルール作成ボタンの修正

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -64,8 +64,13 @@ header {
   .navbar {
     padding: .8rem;
   }
-  .navbar-nav li {
-    padding-right: 20px;
+  .navbar-nav {
+    -webkit-transform: translateY(2px);
+    transform: translateY(2px);
+
+    li:not(:last-child) {
+      padding-right: 20px;
+    }
   }
   .nav-link {
     font-size: 1.1em;
@@ -74,7 +79,7 @@ header {
     border-radius: 50%;
     height: 30px;
     width: 30px;
-    margin-right: 1px;
+    margin-right: 2px;
     -webkit-transform: translateY(-2px);
     transform: translateY(-2px);
   }
@@ -84,6 +89,14 @@ header {
       background-color: #f8f8f8;
       color: #000;
     }
+  }
+  .user-name {
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+    display: inline-block;
+    vertical-align: top;
+    max-width: 180px;
   }
 }
 
@@ -546,10 +559,10 @@ header {
   .fixed-rule-make-btn {
     color: white;
     position: fixed;
-    bottom: 15px;
-    right: 15px;
-    height: 110px;
-    width: 110px;
+    bottom: 25px;
+    right: 25px;
+    height: 140px;
+    width: 140px;
     border-radius: 50%;
     background: #17a2b8;
     text-align: center;
@@ -558,10 +571,11 @@ header {
       text-decoration: none;
     }
     & div {
-      margin: 12px 0 1px 0;
+      font-size: 1.1rem;
+      margin: 18px 0 3px 0;
     }
     & i {
-      font-size: 40px;
+      font-size: 55px;
     }
   }
 }
@@ -579,6 +593,12 @@ footer {
 // media query
 // 中デバイス用（小さめパソコン、大きめタブレット）
 @media (max-width: 991.98px) {
+  header {
+    .user-name {
+      max-width: 135px;
+    }
+  }
+
   .img-caption h1 {
     font-size: 350%;
   }
@@ -596,6 +616,22 @@ footer {
   .btn-signup, .btn-update {
     margin-top: 3rem !important;
   }
+
+  .user-show-wrapper {
+    .fixed-rule-make-btn {
+      bottom: 15px;
+      right: 15px;
+      height: 110px;
+      width: 110px;
+      & div {
+        font-size: 1rem;
+        margin: 12px 0 1px 0;
+      }
+      & i {
+        font-size: 40px;
+      }
+    }
+  }
 }
 
 // 小デバイス用（小さめタブレット）
@@ -610,6 +646,9 @@ footer {
     }
     .nav-link {
       padding: .7rem 1rem;
+    }
+    .user-name {
+      max-width: 230px;
     }
   }
   .img-caption h1 {

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -9,7 +9,7 @@
         %ul.navbar-nav.ml-auto
           - if logged_in?
             %li.nav-item
-              = link_to "自分ルールを作成する", habits_select_path, class: "nav-link"
+              = link_to "自分ルール作成", habits_select_path, class: "nav-link"
             %li.nav-item
               = link_to "自分ルール一覧", current_user, class: "nav-link"
             %li.nav-item.dropdown
@@ -21,7 +21,8 @@
                     = image_tag current_user.image_url, class: "header-avatar"
                 - else
                   = image_tag current_user.avatar.url, class: "header-avatar"
-                = current_user.name
+                %span.user-name
+                  = current_user.name
               .dropdown-menu.dropdown-menu-right{"aria-haspopup" => "true"}
                 - if current_user.admin?
                   = link_to "管理ページ", admin_users_path, class: "dropdown-item"


### PR DESCRIPTION
close #169 

## 概要
- ヘッダーのユーザー名の長さが一定以上になると省略して表示されるように修正（username...みたいになる）
- マイページのルール作成ボタンを画面サイズによってもう一段階大きくなるように修正

## テスト内容
- chromeの検証ツールで表示を確認

## 参考URL
- [CSSではみ出したテキストを「...」で省略](https://qiita.com/tksnino/items/4cf63bd1fc86a69daba0)
- [CSS：last-childより「last-child以外」の方がブラウザにやさしい](https://hacknote.jp/archives/30929/)