### PR TITLE
「さっそく始める」ボタンのリンク先を新規登録ページにする

### DIFF
--- a/app/views/static_pages/home.html.haml
+++ b/app/views/static_pages/home.html.haml
@@ -16,4 +16,4 @@
           新しい習慣づくりはもちろん、悪い習慣をやめるためにも使えます。
       - unless logged_in?
         .offset-2.col-8.offset-md-3.col-md-6
-          = link_to "さっそく始める", login_path, class: "btn-gradient my-5"
+          = link_to "さっそく始める", signup_path, class: "btn-gradient my-5"


### PR DESCRIPTION
close #172 

## 概要
- トップページの「さっそく始める」ボタンのリンク先を新規登録ページに戻す
  - 新規登録ページにもお試しログインボタンを置いてあるから問題ない

## テスト内容
- ブラウザ上でリンク先が新規登録ページになっていることを確認

## 補足
- このissueやってる時にrailsコマンドが使えなったのとDBに接続できなくなるエラーで１時間くらい溶かした、、、
  - 原因はおそらくhomebrewがupdateされたこと
  - rubyとpostgresqlを再インストールして`brew postgresql-upgrade-database`コマンドを入力して解決